### PR TITLE
Fix: 멘토님 네 분을 PR에 멘션하는 것으로 수정

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -5,7 +5,4 @@
 ## Linked Issues
 
 ## 멘토님들
-@kimwonyong
-@kwangdosa
-@mysticPrg
-@chanmo-kim
+@boostcamp-2020/accountbook_mentor

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -6,5 +6,6 @@
 
 ## 멘토님들
 @kimwonyong
-
 @kwangdosa
+@mysticPrg
+@chanmo-kim


### PR DESCRIPTION
멘토님 네 분을 전부 멘션해야 하므로 멘토님 네 분의 깃헙 아이디를 모두 멘션한다.


