### PR TITLE
DropdownHeader 컴포넌트 생성

### DIFF
--- a/fe/.eslintrc.js
+++ b/fe/.eslintrc.js
@@ -28,6 +28,7 @@ module.exports = {
   rules: {
     'react/prop-types': 0,
     'no-undef': 0,
+    'react/require-default-props': 0,
     'import/no-extraneous-dependencies': 0,
     'react/jsx-filename-extension': [
       1,

--- a/fe/src/components/molecules/DropdownHeader/DropdownHeader.stories.tsx
+++ b/fe/src/components/molecules/DropdownHeader/DropdownHeader.stories.tsx
@@ -1,0 +1,26 @@
+import React from 'react';
+import { ThemeProvider } from 'styled-components';
+import theme from 'styles/theme';
+import { withKnobs, select } from '@storybook/addon-knobs';
+import DropdownButton from '.';
+
+export default {
+  title: 'molecules/DropdownHeader',
+  component: DropdownButton,
+  decorators: [withKnobs],
+};
+
+export const dropdownHeader = () => {
+  const title = select('title', ['11월', '필터', '드랍다운', ''], '11월');
+  const child = new Array(10)
+    .fill(0)
+    .map((x, i) => i)
+    .map((index) => <div key={index}>{index}</div>);
+  return (
+    <ThemeProvider theme={theme}>
+      <DropdownButton title={title}>
+        <div>{child}</div>
+      </DropdownButton>
+    </ThemeProvider>
+  );
+};

--- a/fe/src/components/molecules/DropdownHeader/index.tsx
+++ b/fe/src/components/molecules/DropdownHeader/index.tsx
@@ -1,0 +1,25 @@
+import React, { useState } from 'react';
+import DropdownButton from './style';
+
+interface Props {
+  title?: String;
+  children: React.ReactElement;
+}
+const arrowCharacter = '▾';
+
+const DropdownButtonHeader = ({ title = '', children }: Props) => {
+  const [visible, setVisible] = useState(false);
+  const toggleVisible = () => {
+    setVisible(!visible);
+  };
+  return (
+    <div>
+      <DropdownButton onClick={toggleVisible}>
+        <div>{`${title} ${arrowCharacter}`}</div>
+      </DropdownButton>
+      {visible && children}
+    </div>
+  );
+};
+
+export default DropdownButtonHeader;

--- a/fe/src/components/molecules/DropdownHeader/index.tsx
+++ b/fe/src/components/molecules/DropdownHeader/index.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useState, useRef, useEffect } from 'react';
 import DropdownButton from './style';
 
 interface Props {
@@ -9,11 +9,28 @@ const arrowCharacter = '▾';
 
 const DropdownButtonHeader = ({ title = '', children }: Props) => {
   const [visible, setVisible] = useState(false);
+  const dropdownContainer = useRef<HTMLDivElement>(null);
+  const outsideClickHandler = (event: any) => {
+    if (!dropdownContainer.current) return;
+    if (
+      dropdownContainer &&
+      !dropdownContainer.current.contains(event.target)
+    ) {
+      setVisible(false);
+    }
+  };
+  useEffect(() => {
+    document.addEventListener('click', outsideClickHandler);
+    return () => {
+      document.removeEventListener('click', outsideClickHandler);
+    };
+  });
+
   const toggleVisible = () => {
     setVisible(!visible);
   };
   return (
-    <div>
+    <div ref={dropdownContainer}>
       <DropdownButton onClick={toggleVisible}>
         <div>{`${title} ${arrowCharacter}`}</div>
       </DropdownButton>

--- a/fe/src/components/molecules/DropdownHeader/style.ts
+++ b/fe/src/components/molecules/DropdownHeader/style.ts
@@ -1,0 +1,9 @@
+import styled from 'styled-components';
+import Button from 'components/atoms/Button';
+
+const DropdownButton = styled(Button)`
+  background: transparent;
+  border: 0;
+`;
+
+export default DropdownButton;


### PR DESCRIPTION
## 변경사항 
![DropdownHeader](https://user-images.githubusercontent.com/44409642/100054746-03c95480-2e66-11eb-8bc6-bb2a7814a250.gif)

- 해더에 `visible` state를 가지고 있어서 하단 컨텐츠를 보여주고 사라지도록 하였습니다.
- document에 click 이벤트와 Ref를 이용하여 현재 element이외에 클릭 했을 때 컨텐츠가 사라지도록 하였습니다.

## 체크리스트
- [x] 버튼을 클릭하였을 경우, 버튼 밑으로 빈 드랍다운이 보여지도록 한다.
- [x] 드랍다운이 보이는 채로, 드랍다운 외부를 클릭하면, 드랍다운이 사라지도록 한다.
## Linked Issues



## 멘토님들
@boostcamp-2020/accountbook_mentor
