### PR TITLE
글로벌 스타일 지정 및 ThemeProvider와 합침

### DIFF
--- a/fe/src/components/atoms/Button/index.tsx
+++ b/fe/src/components/atoms/Button/index.tsx
@@ -4,7 +4,7 @@ import { ButtonStyle } from './style';
 export interface Props {
   size?: string;
   onClick?: React.MouseEventHandler<HTMLButtonElement>;
-  children: React.ReactElement | React.ReactElement[] | string;
+  children?: React.ReactElement | React.ReactElement[] | string;
 }
 
 const Button = ({ size, onClick, children, ...props }: Props) => {

--- a/fe/src/components/atoms/PriceTag/PriceTag.stories.tsx
+++ b/fe/src/components/atoms/PriceTag/PriceTag.stories.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { withKnobs, select, number } from '@storybook/addon-knobs';
-import { ThemeProvider } from 'styled-components';
-import theme from '../../../styles/theme';
+import GlobalThemeProvider from 'styles/GlobalThemeProvider';
+import theme from 'styles/theme';
 
 import PriceTag from '.';
 
@@ -16,8 +16,8 @@ export const priceTag = () => {
   const bold = select('bold', [true, false], true);
   const color = select('color', Object.keys(theme.color), 'black');
   return (
-    <ThemeProvider theme={theme}>
+    <GlobalThemeProvider>
       <PriceTag value={value} size={size} bold={bold} color={color} />
-    </ThemeProvider>
+    </GlobalThemeProvider>
   );
 };

--- a/fe/src/styles/GlobalStyle.ts
+++ b/fe/src/styles/GlobalStyle.ts
@@ -1,0 +1,12 @@
+import { createGlobalStyle } from 'styled-components';
+
+const GlobalStyle = createGlobalStyle`
+  @font-face {
+      font-family: 'BMEULJIRO';
+      src: url('https://cdn.jsdelivr.net/gh/projectnoonnu/noonfonts_twelve@1.0/BMEULJIRO.woff') format('woff');
+      font-weight: normal;
+      font-style: normal;
+  }
+`;
+
+export default GlobalStyle;

--- a/fe/src/styles/GlobalThemeProvider.tsx
+++ b/fe/src/styles/GlobalThemeProvider.tsx
@@ -1,0 +1,19 @@
+/* eslint-disable react/require-default-props */
+import React from 'react';
+import { ThemeProvider } from 'styled-components';
+import theme from './theme';
+import GlobalStyle from './GlobalStyle';
+
+interface Prop {
+  children?: React.ReactElement | React.ReactElement[] | string;
+}
+const GlobalThemeProvider = ({ children }: Prop) => {
+  return (
+    <ThemeProvider theme={theme}>
+      <GlobalStyle />
+      {children}
+    </ThemeProvider>
+  );
+};
+
+export default GlobalThemeProvider;


### PR DESCRIPTION
## 변경사항 
```js
return (
    <ThemeProvider theme={theme}>
      <GlobalStyle />
      {children}
    </ThemeProvider>
  );
```

- 스토리북에서 계속 theme를 불러와서 적용해야 함 -> 적용한 것을 리턴하는 컴포넌트 생성
- 추가적으로 GlobalStyle도 같이 전역으로 사용되어 같이 묶음.
## 체크리스트
- [x] GlobalStyle 정의
## Linked Issues

## 멘토님들
@boostcamp-2020/accountbook_mentor
