### PR TITLE
TransactionAPI year, month를 startDate, endDate로 수정

### DIFF
--- a/be/src/controllers/transaction/index.ts
+++ b/be/src/controllers/transaction/index.ts
@@ -2,8 +2,8 @@ import Koa from 'koa';
 import { getTransaction, saveAndAddToAccount } from 'services/transaction';
 
 const get = async (ctx: Koa.Context) => {
-  const { year, month } = ctx.query;
-  const res = await getTransaction({ year, month });
+  const { startDate, endDate } = ctx.query;
+  const res = await getTransaction({ startDate, endDate });
   ctx.status = 200;
   ctx.body = res;
 };

--- a/be/src/services/transaction/index.ts
+++ b/be/src/services/transaction/index.ts
@@ -1,5 +1,4 @@
 import { TransactionModel, Transaction, AccountModel } from 'models';
-import getOneMonthRange from 'libs/date';
 
 const oneMonthTransactionsReducer = (acc: any, transaction: Transaction) => {
   const year = transaction.date.getFullYear();
@@ -10,19 +9,20 @@ const oneMonthTransactionsReducer = (acc: any, transaction: Transaction) => {
     ? { ...acc, [key]: [...acc[key], transaction] }
     : { ...acc, [key]: [transaction] };
 };
+
 export const getTransaction = async ({
-  year,
-  month,
+  startDate,
+  endDate,
 }: {
-  year: string;
-  month: string;
+  startDate: string;
+  endDate: string;
 }) => {
   const oneMonthTransactions: Transaction[] = await TransactionModel.find()
     .populate('category')
     .populate('method')
     .where('date')
-    .gte(new Date(getOneMonthRange(year, month).start))
-    .lt(new Date(getOneMonthRange(year, month).end))
+    .gte(new Date(startDate))
+    .lt(new Date(endDate))
     .sort('date');
 
   const result = oneMonthTransactions.reduce(oneMonthTransactionsReducer, {});


### PR DESCRIPTION
## 변경사항 
year, month로 query를 날리던 걸 startDate, endDate로 수정했습니다.

## Linked Issues
closes #82 

## 멘토님들
@boostcamp-2020/accountbook_mentor
