### PR TITLE
Transaction GET API가 accountid 참고해서 가져오도록 수정

### DIFF
--- a/be/src/controllers/transaction/index.ts
+++ b/be/src/controllers/transaction/index.ts
@@ -3,7 +3,8 @@ import { getTransaction, saveAndAddToAccount } from 'services/transaction';
 
 const get = async (ctx: Koa.Context) => {
   const { startDate, endDate } = ctx.query;
-  const res = await getTransaction({ startDate, endDate });
+  const { accountObjId } = ctx.params;
+  const res = await getTransaction({ startDate, endDate, accountObjId });
   ctx.status = 200;
   ctx.body = res;
 };

--- a/be/src/models/account/index.ts
+++ b/be/src/models/account/index.ts
@@ -1,9 +1,10 @@
+import { ITransaction } from 'models/transaction';
 import { Schema, Types, model, Document, Model } from 'mongoose';
 import { findByPkAndPushTransaction } from './static';
 
 export interface IAccount {
   title: string;
-  transactions?: string[];
+  transactions?: string[] | ITransaction[];
   categories?: string[];
   methods?: string[];
 }

--- a/be/src/services/transaction/index.ts
+++ b/be/src/services/transaction/index.ts
@@ -1,6 +1,31 @@
 import { TransactionModel, ITransaction } from 'models/transaction';
 import { AccountModel } from 'models/account';
 
+const findTransactionsAndBindWithDateKey = (
+  startDate: string,
+  endDate: string,
+) => async (acc: any, transactionId: string) => {
+  const res = await TransactionModel.findOne({ _id: transactionId })
+    .populate('category')
+    .populate('method')
+    .where('date')
+    .gte(new Date(startDate))
+    .lt(new Date(endDate));
+  if (!res) {
+    return acc;
+  }
+  const resDate = res.date;
+  const resKey = `${resDate.getFullYear()}-${
+    resDate.getMonth() + 1
+  }-${resDate.getDate()}`;
+
+  if (acc[resKey]) {
+    return acc[resKey].push(res);
+  }
+  acc[resKey] = res;
+  return { ...acc };
+};
+
 const oneMonthTransactionsReducer = (acc: any, transaction: ITransaction) => {
   const year = transaction.date.getFullYear();
   const month = transaction.date.getMonth() + 1;
@@ -14,19 +39,36 @@ const oneMonthTransactionsReducer = (acc: any, transaction: ITransaction) => {
 export const getTransaction = async ({
   startDate,
   endDate,
+  accountObjId,
 }: {
   startDate: string;
   endDate: string;
+  accountObjId: string;
 }) => {
-  const oneMonthTransactions: ITransaction[] = await TransactionModel.find()
-    .populate('category')
-    .populate('method')
-    .where('date')
-    .gte(new Date(startDate))
-    .lt(new Date(endDate))
-    .sort('date');
+  const res = await AccountModel.findOne({
+    _id: accountObjId,
+  })
+    .populate({
+      path: 'transactions',
+      match: { date: { $gte: startDate, $lt: endDate } },
+      populate: { path: 'category methods' },
+    })
+    .exec();
 
-  const result = oneMonthTransactions.reduce(oneMonthTransactionsReducer, {});
+  if (!res) {
+    return { message: 'nodata' };
+  }
+
+  const trans = await res.transactions;
+  if (trans.length === 0) {
+    return { message: 'nodata' };
+  }
+
+  trans.sort((firstEl: any, secondEl: any) => {
+    return firstEl.date - secondEl.date;
+  });
+
+  const result = trans.reduce(oneMonthTransactionsReducer, {});
   return result;
 };
 

--- a/be/src/services/transaction/index.ts
+++ b/be/src/services/transaction/index.ts
@@ -60,7 +60,7 @@ export const getTransaction = async ({
   }
 
   const trans = await res.transactions;
-  if (trans.length === 0) {
+  if (!trans || trans.length === 0) {
     return { message: 'nodata' };
   }
 
@@ -68,7 +68,10 @@ export const getTransaction = async ({
     return firstEl.date - secondEl.date;
   });
 
-  const result = trans.reduce(oneMonthTransactionsReducer, {});
+  const result = (trans as ITransaction[]).reduce(
+    oneMonthTransactionsReducer,
+    {},
+  );
   return result;
 };
 


### PR DESCRIPTION
## 변경사항 
Transaction GET API를 쓸 때 AccountId에 맞는 Transaction만 보여주게 수정했습니다.
```api/transactions/:obj_id``` <- 필수

## 체크리스트
- [x]  obj_id에 맞는 가계부의 Transaction만 접근할 수 있다.
## Linked Issues
closes #54 

## 멘토님들
@boostcamp-2020/accountbook_mentor
