### PR TITLE
프론트에서 transaction get시 데이터 없을 때 에러 핸들링

### DIFF
--- a/be/src/controllers/transaction/index.ts
+++ b/be/src/controllers/transaction/index.ts
@@ -3,7 +3,8 @@ import { getTransaction, saveAndAddToAccount } from 'services/transaction';
 
 const get = async (ctx: Koa.Context) => {
   const { startDate, endDate } = ctx.query;
-  const res = await getTransaction({ startDate, endDate });
+  const { accountObjId } = ctx.params;
+  const res = await getTransaction({ startDate, endDate, accountObjId });
   ctx.status = 200;
   ctx.body = res;
 };

--- a/be/src/models/account/index.ts
+++ b/be/src/models/account/index.ts
@@ -1,9 +1,10 @@
+import { ITransaction } from 'models/transaction';
 import { Schema, Types, model, Document, Model } from 'mongoose';
 import { findByPkAndPushTransaction } from './static';
 
 export interface IAccount {
   title: string;
-  transactions?: string[];
+  transactions?: string[] | ITransaction[];
   categories?: string[];
   methods?: string[];
 }

--- a/be/src/services/transaction/index.ts
+++ b/be/src/services/transaction/index.ts
@@ -1,6 +1,31 @@
 import { TransactionModel, ITransaction } from 'models/transaction';
 import { AccountModel } from 'models/account';
 
+const findTransactionsAndBindWithDateKey = (
+  startDate: string,
+  endDate: string,
+) => async (acc: any, transactionId: string) => {
+  const res = await TransactionModel.findOne({ _id: transactionId })
+    .populate('category')
+    .populate('method')
+    .where('date')
+    .gte(new Date(startDate))
+    .lt(new Date(endDate));
+  if (!res) {
+    return acc;
+  }
+  const resDate = res.date;
+  const resKey = `${resDate.getFullYear()}-${
+    resDate.getMonth() + 1
+  }-${resDate.getDate()}`;
+
+  if (acc[resKey]) {
+    return acc[resKey].push(res);
+  }
+  acc[resKey] = res;
+  return { ...acc };
+};
+
 const oneMonthTransactionsReducer = (acc: any, transaction: ITransaction) => {
   const year = transaction.date.getFullYear();
   const month = transaction.date.getMonth() + 1;
@@ -14,19 +39,36 @@ const oneMonthTransactionsReducer = (acc: any, transaction: ITransaction) => {
 export const getTransaction = async ({
   startDate,
   endDate,
+  accountObjId,
 }: {
   startDate: string;
   endDate: string;
+  accountObjId: string;
 }) => {
-  const oneMonthTransactions: ITransaction[] = await TransactionModel.find()
-    .populate('category')
-    .populate('method')
-    .where('date')
-    .gte(new Date(startDate))
-    .lt(new Date(endDate))
-    .sort('date');
+  const res = await AccountModel.findOne({
+    _id: accountObjId,
+  })
+    .populate({
+      path: 'transactions',
+      match: { date: { $gte: startDate, $lt: endDate } },
+      populate: { path: 'category methods' },
+    })
+    .exec();
 
-  const result = oneMonthTransactions.reduce(oneMonthTransactionsReducer, {});
+  if (!res) {
+    return { message: 'nodata' };
+  }
+
+  const trans = await res.transactions;
+  if (trans.length === 0) {
+    return { message: 'nodata' };
+  }
+
+  trans.sort((firstEl: any, secondEl: any) => {
+    return firstEl.date - secondEl.date;
+  });
+
+  const result = trans.reduce(oneMonthTransactionsReducer, {});
   return result;
 };
 

--- a/be/src/services/transaction/index.ts
+++ b/be/src/services/transaction/index.ts
@@ -1,31 +1,6 @@
 import { TransactionModel, ITransaction } from 'models/transaction';
 import { AccountModel } from 'models/account';
 
-const findTransactionsAndBindWithDateKey = (
-  startDate: string,
-  endDate: string,
-) => async (acc: any, transactionId: string) => {
-  const res = await TransactionModel.findOne({ _id: transactionId })
-    .populate('category')
-    .populate('method')
-    .where('date')
-    .gte(new Date(startDate))
-    .lt(new Date(endDate));
-  if (!res) {
-    return acc;
-  }
-  const resDate = res.date;
-  const resKey = `${resDate.getFullYear()}-${
-    resDate.getMonth() + 1
-  }-${resDate.getDate()}`;
-
-  if (acc[resKey]) {
-    return acc[resKey].push(res);
-  }
-  acc[resKey] = res;
-  return { ...acc };
-};
-
 const oneMonthTransactionsReducer = (acc: any, transaction: ITransaction) => {
   const year = transaction.date.getFullYear();
   const month = transaction.date.getMonth() + 1;

--- a/be/src/services/transaction/index.ts
+++ b/be/src/services/transaction/index.ts
@@ -60,7 +60,7 @@ export const getTransaction = async ({
   }
 
   const trans = await res.transactions;
-  if (trans.length === 0) {
+  if (!trans || trans.length === 0) {
     return { message: 'nodata' };
   }
 
@@ -68,7 +68,10 @@ export const getTransaction = async ({
     return firstEl.date - secondEl.date;
   });
 
-  const result = trans.reduce(oneMonthTransactionsReducer, {});
+  const result = (trans as ITransaction[]).reduce(
+    oneMonthTransactionsReducer,
+    {},
+  );
   return result;
 };
 

--- a/fe/src/pages/MainPage/TransactionDateList.tsx
+++ b/fe/src/pages/MainPage/TransactionDateList.tsx
@@ -2,6 +2,9 @@ import React from 'react';
 import AccountDate from 'components/organisms/AccountDate';
 
 const convertTransactionDBTypetoTransactionType = (input: any[]) => {
+  if (typeof input === 'string') {
+    return [{ id: 'noId', category: 'nocategory', method: 'nomethod' }];
+  }
   return input.map((el) => {
     const { _id, category, method, ...other } = el;
     return {

--- a/fe/src/stores/Transaction/transactionStoreUtils.ts
+++ b/fe/src/stores/Transaction/transactionStoreUtils.ts
@@ -26,6 +26,9 @@ const TransactionsReduce = (
 export const calTotalPrices = (list: any) => {
   return Object.values<any[]>(list).reduce(
     (acc: { income: number; expense: number }, transactions) => {
+      if (typeof transactions === 'string') {
+        return acc;
+      }
       const res = transactions.reduce(TransactionsReduce, {
         ...initTotalPrice,
       });


### PR DESCRIPTION
## 변경사항 
Transaction GET Api 호출에 실패하면 프론트에서 발생하는 에러 핸들링 코드 추가

## 이번 PR 변경
https://github.com/boostcamp-2020/Project16-A-Account-Book/pull/99/files/a7841ca159d364fbc1c22b40fd93e08ae46ce6ca..253b7569df0f6245ebcadbab69472f401166aaa1

## 멘토님들
@boostcamp-2020/accountbook_mentor
