### PR TITLE
MonthInfoHeader에 필요한 수입 지출 calculate로 구하도록 수정

### DIFF
--- a/be/src/services/transaction/index.ts
+++ b/be/src/services/transaction/index.ts
@@ -47,7 +47,7 @@ export const getTransaction = async ({
     return { message: 'nodata' };
   }
 
-  const trans = await res.transactions;
+  const trans = res.transactions;
   if (!trans || trans.length === 0) {
     return { message: 'nodata' };
   }

--- a/fe/src/pages/CalenderPage/index.tsx
+++ b/fe/src/pages/CalenderPage/index.tsx
@@ -7,24 +7,16 @@ import Header from 'components/organisms/HeaderBar';
 import MonthInfo from 'components/organisms/MonthInfoHeader';
 import Calender from 'components/organisms/Calender';
 import NavBarComponent from 'components/organisms/NavBar';
-import { calTotalPrices } from 'stores/Transaction/transactionStoreUtils';
-import date from 'utils/date';
-
-const { start, end } = date.getOneMonthRange(
-  String(new Date().getFullYear()),
-  String(new Date().getMonth() + 1),
-);
 
 const CalenderPage = () => {
   useEffect(() => {
-    TransactionStore.setFilter(new Date(start), new Date(end), null);
     TransactionStore.loadTransactions();
   }, []);
 
   const SubHeaderBar = (
     <MonthInfo
       month={toJS(TransactionStore.dates.startDate.getMonth() + 1)}
-      total={calTotalPrices(toJS(TransactionStore.transactions))}
+      total={TransactionStore.transactions}
     />
   );
 

--- a/fe/src/pages/CalenderPage/index.tsx
+++ b/fe/src/pages/CalenderPage/index.tsx
@@ -16,7 +16,7 @@ const CalenderPage = () => {
   const SubHeaderBar = (
     <MonthInfo
       month={toJS(TransactionStore.dates.startDate.getMonth() + 1)}
-      total={TransactionStore.transactions}
+      total={TransactionStore.totalPrices}
     />
   );
 

--- a/fe/src/pages/MainPage/index.tsx
+++ b/fe/src/pages/MainPage/index.tsx
@@ -7,25 +7,24 @@ import Header from 'components/organisms/HeaderBar';
 import FilterBar from 'components/organisms/FilterBar';
 import MonthInfo from 'components/organisms/MonthInfoHeader';
 import NavBarComponent from 'components/organisms/NavBar';
-import { calTotalPrices } from 'stores/Transaction/transactionStoreUtils';
-import date from 'utils/date';
+// import date from 'utils/date';
 import TransactionDateList from './TransactionDateList';
 
-const { start, end } = date.getOneMonthRange(
-  String(new Date().getFullYear()),
-  String(new Date().getMonth() + 1),
-);
+// const { start, end } = date.getOneMonthRange(
+//   String(new Date().getFullYear()),
+//   String(new Date().getMonth() + 1),
+// );
 
 const MainPage = () => {
   useEffect(() => {
-    TransactionStore.setFilter(new Date(start), new Date(end), null);
+    // TransactionStore.setFilter(new Date(start), new Date(end), null);
     TransactionStore.loadTransactions();
   }, []);
 
   const SubHeaderBar = (
     <MonthInfo
       month={toJS(TransactionStore.dates.startDate.getMonth() + 1)}
-      total={calTotalPrices(toJS(TransactionStore.transactions))}
+      total={TransactionStore.totalPrices}
     />
   );
 

--- a/fe/src/pages/MainPage/index.tsx
+++ b/fe/src/pages/MainPage/index.tsx
@@ -7,17 +7,10 @@ import Header from 'components/organisms/HeaderBar';
 import FilterBar from 'components/organisms/FilterBar';
 import MonthInfo from 'components/organisms/MonthInfoHeader';
 import NavBarComponent from 'components/organisms/NavBar';
-// import date from 'utils/date';
 import TransactionDateList from './TransactionDateList';
-
-// const { start, end } = date.getOneMonthRange(
-//   String(new Date().getFullYear()),
-//   String(new Date().getMonth() + 1),
-// );
 
 const MainPage = () => {
   useEffect(() => {
-    // TransactionStore.setFilter(new Date(start), new Date(end), null);
     TransactionStore.loadTransactions();
   }, []);
 

--- a/fe/src/pages/StatisticsPage/index.tsx
+++ b/fe/src/pages/StatisticsPage/index.tsx
@@ -6,7 +6,6 @@ import Template from 'components/templates/MainTemplate';
 import Header from 'components/organisms/HeaderBar';
 import MonthInfo from 'components/organisms/MonthInfoHeader';
 import NavBarComponent from 'components/organisms/NavBar';
-import { calTotalPrices } from 'stores/Transaction/transactionStoreUtils';
 import useStatistics from 'hooks/useStatistics';
 import PieChartOverview from 'components/organisms/PieChartOverview';
 
@@ -15,7 +14,7 @@ const StatisticsPage = () => {
   const SubHeaderBar = (
     <MonthInfo
       month={toJS(TransactionStore.dates.startDate.getMonth() + 1)}
-      total={calTotalPrices(toJS(TransactionStore.transactions))}
+      total={TransactionStore.totalPrices}
     />
   );
 

--- a/fe/src/stores/Transaction/index.ts
+++ b/fe/src/stores/Transaction/index.ts
@@ -78,6 +78,11 @@ export const TransactionStore = makeAutoObservable({
     };
   },
   get totalPrices() {
+    if (this.state === state.PENDING) {
+      // TODO PENDING 일 때 0,0을 보여주면 잠시 깜빡거림
+      // 로딩관련 글씨를 보여주면 좋을 듯
+      return { income: 0, expense: 0 };
+    }
     return calTotalPrices(this.transactions);
   },
   async loadTransactions() {

--- a/fe/src/stores/Transaction/index.ts
+++ b/fe/src/stores/Transaction/index.ts
@@ -2,6 +2,7 @@ import { makeAutoObservable, runInAction } from 'mobx';
 import transactionAPI from 'apis/transaction';
 import date from 'utils/date';
 import * as types from 'types';
+import { calTotalPrices } from 'stores/Transaction/transactionStoreUtils';
 import { testAccountDateList } from './testData';
 
 export interface ITransactionStore {
@@ -75,6 +76,9 @@ export const TransactionStore = makeAutoObservable({
       startDate: date.dateFormatter(this.dates.startDate),
       endDate: date.dateFormatter(this.dates.endDate),
     };
+  },
+  get totalPrices() {
+    return calTotalPrices(this.transactions);
   },
   async loadTransactions() {
     this.state = state.PENDING;


### PR DESCRIPTION
## 변경사항 
![image](https://user-images.githubusercontent.com/34783156/101226876-37fc0b00-36d9-11eb-8458-c431905bae11.png)
수입 지출 : 중간에 수입 지출을 의미
기존 : 필요한 수입 지출을 Page에서 직접 구해줬음
개선 : mobx 의 calculate로 mobx단에서 계산해서 리턴하도록 수정 

## TODO
Transasction Store가 DB에서 값을 가져오는 PENDING 상태일 때 totalPrices 를 { income: 0, expense: 0 } 을 return하도록 수정했는데 0, 0에서 새로 계산된 값으로 바뀌는 과정에서 깜빡임이 있음 이 것 수정 #114

## Linked Issues
#113 -> 논의 필요

## 멘토님들
@boostcamp-2020/accountbook_mentor
