### PR TITLE
Transaction 없을 때 'nodata' 리턴했던 것 빈 배열로 수정

### DIFF
--- a/be/src/controllers/transaction/index.ts
+++ b/be/src/controllers/transaction/index.ts
@@ -5,7 +5,11 @@ const get = async (ctx: Koa.Context) => {
   const { startDate, endDate } = ctx.query;
   const { accountObjId } = ctx.params;
   const res = await getTransaction({ startDate, endDate, accountObjId });
-  ctx.status = 200;
+  if (res.length === 0) {
+    ctx.status = 204;
+  } else {
+    ctx.status = 200;
+  }
   ctx.body = res;
 };
 

--- a/be/src/services/transaction/index.ts
+++ b/be/src/services/transaction/index.ts
@@ -1,6 +1,7 @@
 import { TransactionModel, ITransaction } from 'models/transaction';
 import { AccountModel } from 'models/account';
 import { categoryType } from 'models/category';
+import { getCompFuncByKey } from 'libs/utils';
 
 const oneMonthTransactionsReducer = (acc: any, transaction: ITransaction) => {
   const year = transaction.date.getFullYear();
@@ -52,9 +53,7 @@ export const getTransaction = async ({
     return { message: 'nodata' };
   }
 
-  trans.sort((firstEl: any, secondEl: any) => {
-    return firstEl.date - secondEl.date;
-  });
+  trans.sort(getCompFuncByKey('date'));
 
   const result = (trans as ITransaction[]).reduce(
     oneMonthTransactionsReducer,

--- a/be/src/services/transaction/index.ts
+++ b/be/src/services/transaction/index.ts
@@ -45,12 +45,12 @@ export const getTransaction = async ({
     .exec();
 
   if (!res) {
-    return { message: 'nodata' };
+    return [];
   }
 
   const trans = res.transactions;
   if (!trans || trans.length === 0) {
-    return { message: 'nodata' };
+    return [];
   }
 
   trans.sort(getCompFuncByKey('date'));

--- a/be/src/services/transaction/index.ts
+++ b/be/src/services/transaction/index.ts
@@ -47,7 +47,7 @@ export const getTransaction = async ({
     return { message: 'nodata' };
   }
 
-  const trans = await res.transactions;
+  const trans = res.transactions;
   if (!trans || trans.length === 0) {
     return { message: 'nodata' };
   }

--- a/fe/src/components/organisms/Calender/index.tsx
+++ b/fe/src/components/organisms/Calender/index.tsx
@@ -1,6 +1,5 @@
 import React from 'react';
-import { TransactionStore } from 'stores/Transaction';
-import { toJS } from 'mobx';
+import date from 'utils/date';
 import * as S from './style';
 
 export interface Props {
@@ -22,7 +21,9 @@ const Calender = ({
   ...props
 }: Props): React.ReactElement => {
   const defaultStartDay = isSundayStart ? 0 : 1;
-
+  if (JSON.stringify(transactions) === '{}') {
+    return <>해당하는 기간에 데이터가 없습니다.</>;
+  }
   const { oneDateList } = Object.entries(transactions).reduce(
     (acc: accType, el: any) => {
       const [key, value]: [string, any[]] = el;
@@ -53,11 +54,8 @@ const Calender = ({
       oneDateList: [],
     },
   );
-  const oneDateSecond = 24 * 60 * 60 * 1000;
-  const nowDate = toJS(TransactionStore.dates.startDate);
-  const maxDate =
-    (toJS(TransactionStore.dates.endDate).getTime() - nowDate.getTime()) /
-    oneDateSecond;
+  const nowDate = new Date(oneDateList[0].date);
+  const maxDate = date.monthMaxDate(nowDate);
   const nowYear = nowDate.getFullYear();
   const nowMonth = nowDate.getMonth();
   const oneWeekListData = [];
@@ -92,6 +90,7 @@ const Calender = ({
     <S.Calender {...props}>
       <S.DayBar isSundayStart={isSundayStart} />
       {oneWeekComponentList}
+      <S.CenterMonth>{nowMonth + 1}</S.CenterMonth>
     </S.Calender>
   );
 };

--- a/fe/src/components/organisms/Calender/style.ts
+++ b/fe/src/components/organisms/Calender/style.ts
@@ -5,6 +5,7 @@ import CalenderDayBar from 'components/molecules/CalenderDayBar';
 
 export const Calender = styled.div`
   display: flex;
+  position: relative;
   flex-direction: column;
 `;
 
@@ -12,4 +13,15 @@ export const DayBar = styled(CalenderDayBar)``;
 
 export const OneWeek = styled(CalenderOneWeek)`
   width: 100%;
+`;
+
+export const CenterMonth = styled.div`
+  font-size: 6rem;
+  color: rgba(0, 0, 0, 0.2);
+  width: 12rem;
+  height: 4rem;
+  position: absolute;
+  left: calc(50% - 6rem);
+  top: calc(50% - 2rem);
+  text-align: center;
 `;

--- a/fe/src/components/organisms/CalenderBind/index.stories.tsx
+++ b/fe/src/components/organisms/CalenderBind/index.stories.tsx
@@ -1,10 +1,10 @@
 import React from 'react';
 import GlobalThemeProvider from 'styles/GlobalThemeProvider';
-import BindCalender from '.';
+import CalenderBind from '.';
 
 export default {
-  title: 'Organisms / BindCalender',
-  component: BindCalender,
+  title: 'Organisms / CalenderBind',
+  component: CalenderBind,
 };
 
 const testAccountDateList = {
@@ -192,7 +192,7 @@ const testAccountDateList = {
 export const SundayStart = () => {
   return (
     <GlobalThemeProvider>
-      <BindCalender isSundayStart transactions={testAccountDateList} />
+      <CalenderBind isSundayStart transactions={testAccountDateList} />
     </GlobalThemeProvider>
   );
 };
@@ -200,7 +200,7 @@ export const SundayStart = () => {
 export const MondayStart = () => {
   return (
     <GlobalThemeProvider>
-      <BindCalender isSundayStart={false} transactions={testAccountDateList} />
+      <CalenderBind isSundayStart={false} transactions={testAccountDateList} />
     </GlobalThemeProvider>
   );
 };

--- a/fe/src/components/organisms/CalenderBind/index.stories.tsx
+++ b/fe/src/components/organisms/CalenderBind/index.stories.tsx
@@ -1,0 +1,206 @@
+import React from 'react';
+import GlobalThemeProvider from 'styles/GlobalThemeProvider';
+import BindCalender from '.';
+
+export default {
+  title: 'Organisms / BindCalender',
+  component: BindCalender,
+};
+
+const testAccountDateList = {
+  '2020-10-12': [
+    {
+      excludeFromBudget: false,
+      _id: 'aaa',
+      client: '삼겹살',
+      date: '2020-10-12T00:00:00.000Z',
+      memo: '1일메모',
+      method: {
+        _id: 'naver',
+        title: '네이버페이',
+        __v: 0,
+      },
+      category: {
+        _id: 'incomeid',
+        type: 'INCOME',
+        title: '식사',
+        color: '#102e94',
+        __v: 0,
+      },
+      price: 10000,
+      __v: 0,
+    },
+
+    {
+      excludeFromBudget: false,
+      _id: 'bbb',
+      client: '삼겹살d',
+      date: '2020-10-12T00:20:00.000Z',
+      memo: '1일메모',
+      method: {
+        _id: 'naver',
+        title: '네이버페이',
+        __v: 0,
+      },
+      category: {
+        _id: 'incomeid',
+        type: 'EXPENSE',
+        title: '식사',
+        color: '#102e94',
+        __v: 0,
+      },
+      price: 10000,
+      __v: 0,
+    },
+  ],
+  '2020-10-14': [
+    {
+      excludeFromBudget: false,
+      _id: 'aaa',
+      client: '삼겹살',
+      date: '2020-10-14T00:00:00.000Z',
+      memo: '1일메모',
+      method: {
+        _id: 'naver',
+        title: '네이버페이',
+        __v: 0,
+      },
+      category: {
+        _id: 'incomeid',
+        type: 'INCOME',
+        title: '식사',
+        color: '#102e94',
+        __v: 0,
+      },
+      price: 10000,
+      __v: 0,
+    },
+    {
+      excludeFromBudget: false,
+      _id: 'bbb',
+      client: '삼겹살d',
+      date: '2020-10-14T00:20:00.000Z',
+      memo: '1일메모',
+      method: {
+        _id: 'naver',
+        title: '네이버페이',
+        __v: 0,
+      },
+      category: {
+        _id: 'incomeid',
+        type: 'EXPENSE',
+        title: '식사',
+        color: '#102e94',
+        __v: 0,
+      },
+      price: 10000,
+      __v: 0,
+    },
+  ],
+  '2020-11-12': [
+    {
+      excludeFromBudget: false,
+      _id: 'aaa',
+      client: '삼겹살',
+      date: '2020-11-12T00:00:00.000Z',
+      memo: '1일메모',
+      method: {
+        _id: 'naver',
+        title: '네이버페이',
+        __v: 0,
+      },
+      category: {
+        _id: 'incomeid',
+        type: 'INCOME',
+        title: '식사',
+        color: '#102e94',
+        __v: 0,
+      },
+      price: 10000,
+      __v: 0,
+    },
+
+    {
+      excludeFromBudget: false,
+      _id: 'bbb',
+      client: '삼겹살d',
+      date: '2020-11-12T00:20:00.000Z',
+      memo: '1일메모',
+      method: {
+        _id: 'naver',
+        title: '네이버페이',
+        __v: 0,
+      },
+      category: {
+        _id: 'incomeid',
+        type: 'EXPENSE',
+        title: '식사',
+        color: '#102e94',
+        __v: 0,
+      },
+      price: 10000,
+      __v: 0,
+    },
+  ],
+  '2020-12-12': [
+    {
+      excludeFromBudget: false,
+      _id: 'aaa',
+      client: '삼겹살',
+      date: '2020-12-12T00:00:00.000Z',
+      memo: '1일메모',
+      method: {
+        _id: 'naver',
+        title: '네이버페이',
+        __v: 0,
+      },
+      category: {
+        _id: 'incomeid',
+        type: 'INCOME',
+        title: '식사',
+        color: '#102e94',
+        __v: 0,
+      },
+      price: 10000,
+      __v: 0,
+    },
+
+    {
+      excludeFromBudget: false,
+      _id: 'bbb',
+      client: '삼겹살d',
+      date: '2020-12-12T00:20:00.000Z',
+      memo: '1일메모',
+      method: {
+        _id: 'naver',
+        title: '네이버페이',
+        __v: 0,
+      },
+      category: {
+        _id: 'incomeid',
+        type: 'EXPENSE',
+        title: '식사',
+        color: '#102e94',
+        __v: 0,
+      },
+      price: 10000,
+      __v: 0,
+    },
+  ],
+};
+
+export const SundayStart = () => {
+  return (
+    <GlobalThemeProvider>
+      <BindCalender isSundayStart transactions={testAccountDateList} />
+    </GlobalThemeProvider>
+  );
+};
+
+export const MondayStart = () => {
+  return (
+    <GlobalThemeProvider>
+      <BindCalender isSundayStart={false} transactions={testAccountDateList} />
+    </GlobalThemeProvider>
+  );
+};

--- a/fe/src/components/organisms/CalenderBind/index.tsx
+++ b/fe/src/components/organisms/CalenderBind/index.tsx
@@ -6,7 +6,7 @@ interface Props {
   transactions: any;
 }
 
-const BindCalender = ({
+const CalenderBind = ({
   isSundayStart,
   transactions = {},
   ...props
@@ -36,6 +36,7 @@ const BindCalender = ({
     Calenders.push({ ...nowTransactions });
   }
   const CalenderComponents = Calenders.map((el: any) => {
+    console.log('el : ', el);
     return (
       <S.Calender
         key={JSON.stringify(el)}
@@ -44,8 +45,9 @@ const BindCalender = ({
       />
     );
   });
+  console.log('CalenderComponents ', CalenderComponents);
 
-  return <S.BindCalender {...props}>{CalenderComponents}</S.BindCalender>;
+  return <S.CalenderBind {...props}>{CalenderComponents}</S.CalenderBind>;
 };
 
-export default BindCalender;
+export default CalenderBind;

--- a/fe/src/components/organisms/CalenderBind/index.tsx
+++ b/fe/src/components/organisms/CalenderBind/index.tsx
@@ -36,7 +36,6 @@ const CalenderBind = ({
     Calenders.push({ ...nowTransactions });
   }
   const CalenderComponents = Calenders.map((el: any) => {
-    console.log('el : ', el);
     return (
       <S.Calender
         key={JSON.stringify(el)}
@@ -45,7 +44,6 @@ const CalenderBind = ({
       />
     );
   });
-  console.log('CalenderComponents ', CalenderComponents);
 
   return <S.CalenderBind {...props}>{CalenderComponents}</S.CalenderBind>;
 };

--- a/fe/src/components/organisms/CalenderBind/index.tsx
+++ b/fe/src/components/organisms/CalenderBind/index.tsx
@@ -1,0 +1,51 @@
+import React from 'react';
+import * as S from './style';
+
+interface Props {
+  isSundayStart: boolean;
+  transactions: any;
+}
+
+const BindCalender = ({
+  isSundayStart,
+  transactions = {},
+  ...props
+}: Props): React.ReactElement => {
+  const Calenders: Array<any> = [];
+  let nowKey = '';
+  let nowYearMonthKey = '';
+  let nowTransactions: any = {};
+  Object.entries(transactions).forEach((el) => {
+    const [key, value] = el;
+    const [year, month] = key.split('-');
+    const yearMonthKey = `${year}-${month}`;
+    if (nowKey === '') {
+      nowKey = key;
+      nowYearMonthKey = yearMonthKey;
+    }
+
+    if (nowYearMonthKey !== yearMonthKey) {
+      nowYearMonthKey = yearMonthKey;
+      nowKey = key;
+      Calenders.push({ ...nowTransactions });
+      nowTransactions = {};
+    }
+    nowTransactions[key] = value;
+  });
+  if (nowTransactions.length !== 0) {
+    Calenders.push({ ...nowTransactions });
+  }
+  const CalenderComponents = Calenders.map((el: any) => {
+    return (
+      <S.Calender
+        key={JSON.stringify(el)}
+        isSundayStart={isSundayStart}
+        transactions={el}
+      />
+    );
+  });
+
+  return <S.BindCalender {...props}>{CalenderComponents}</S.BindCalender>;
+};
+
+export default BindCalender;

--- a/fe/src/components/organisms/CalenderBind/style.ts
+++ b/fe/src/components/organisms/CalenderBind/style.ts
@@ -1,0 +1,10 @@
+import styled from 'styled-components';
+
+import CalenderComponent from 'components/organisms/Calender';
+
+export const BindCalender = styled.div`
+  display: flex;
+  flex-direction: column;
+`;
+
+export const Calender = styled(CalenderComponent)``;

--- a/fe/src/components/organisms/CalenderBind/style.ts
+++ b/fe/src/components/organisms/CalenderBind/style.ts
@@ -2,9 +2,10 @@ import styled from 'styled-components';
 
 import CalenderComponent from 'components/organisms/Calender';
 
-export const BindCalender = styled.div`
+export const CalenderBind = styled.div`
   display: flex;
   flex-direction: column;
+  overflow: scroll;
 `;
 
 export const Calender = styled(CalenderComponent)``;

--- a/fe/src/components/organisms/CalenderBind/style.ts
+++ b/fe/src/components/organisms/CalenderBind/style.ts
@@ -5,7 +5,6 @@ import CalenderComponent from 'components/organisms/Calender';
 export const CalenderBind = styled.div`
   display: flex;
   flex-direction: column;
-  overflow: scroll;
 `;
 
 export const Calender = styled(CalenderComponent)``;

--- a/fe/src/pages/CalenderPage/index.tsx
+++ b/fe/src/pages/CalenderPage/index.tsx
@@ -7,24 +7,16 @@ import Header from 'components/organisms/HeaderBar';
 import MonthInfo from 'components/organisms/MonthInfoHeader';
 import Calender from 'components/organisms/Calender';
 import NavBarComponent from 'components/organisms/NavBar';
-import { calTotalPrices } from 'stores/Transaction/transactionStoreUtils';
-import date from 'utils/date';
-
-const { start, end } = date.getOneMonthRange(
-  String(new Date().getFullYear()),
-  String(new Date().getMonth() + 1),
-);
 
 const CalenderPage = () => {
   useEffect(() => {
-    TransactionStore.setFilter(new Date(start), new Date(end), null);
     TransactionStore.loadTransactions();
   }, []);
 
   const SubHeaderBar = (
     <MonthInfo
       month={toJS(TransactionStore.dates.startDate.getMonth() + 1)}
-      total={calTotalPrices(toJS(TransactionStore.transactions))}
+      total={TransactionStore.transactions}
     />
   );
 

--- a/fe/src/pages/CalenderPage/index.tsx
+++ b/fe/src/pages/CalenderPage/index.tsx
@@ -16,7 +16,7 @@ const CalenderPage = () => {
   const SubHeaderBar = (
     <MonthInfo
       month={toJS(TransactionStore.dates.startDate.getMonth() + 1)}
-      total={TransactionStore.transactions}
+      total={TransactionStore.totalPrices}
     />
   );
 

--- a/fe/src/pages/CalenderPage/index.tsx
+++ b/fe/src/pages/CalenderPage/index.tsx
@@ -20,10 +20,7 @@ const CalenderPage = () => {
     />
   );
 
-  if (
-    'message' in TransactionStore.transactions &&
-    toJS(TransactionStore.transactions.message) === 'nodata'
-  ) {
+  if (toJS(TransactionStore.transactions).length === 0) {
     return (
       <Template
         HeaderBar={<Header />}

--- a/fe/src/pages/CalenderPage/index.tsx
+++ b/fe/src/pages/CalenderPage/index.tsx
@@ -5,7 +5,7 @@ import { TransactionStore } from 'stores/Transaction';
 import Template from 'components/templates/MainTemplate';
 import Header from 'components/organisms/HeaderBar';
 import MonthInfo from 'components/organisms/MonthInfoHeader';
-import Calender from 'components/organisms/Calender';
+import CalenderBind from 'components/organisms/CalenderBind';
 import NavBarComponent from 'components/organisms/NavBar';
 
 const CalenderPage = () => {
@@ -28,7 +28,7 @@ const CalenderPage = () => {
       <Template
         HeaderBar={<Header />}
         SubHeaderBar={SubHeaderBar}
-        Contents={<Calender isSundayStart transactions={[]} />}
+        Contents={<CalenderBind isSundayStart transactions={[]} />}
         NavBar={<NavBarComponent />}
       />
     );
@@ -36,7 +36,7 @@ const CalenderPage = () => {
 
   const Contents = (
     <>
-      <Calender
+      <CalenderBind
         isSundayStart
         transactions={toJS(TransactionStore.transactions)}
       />

--- a/fe/src/pages/MainPage/index.tsx
+++ b/fe/src/pages/MainPage/index.tsx
@@ -7,25 +7,24 @@ import Header from 'components/organisms/HeaderBar';
 import FilterBar from 'components/organisms/FilterBar';
 import MonthInfo from 'components/organisms/MonthInfoHeader';
 import NavBarComponent from 'components/organisms/NavBar';
-import { calTotalPrices } from 'stores/Transaction/transactionStoreUtils';
-import date from 'utils/date';
+// import date from 'utils/date';
 import TransactionDateList from './TransactionDateList';
 
-const { start, end } = date.getOneMonthRange(
-  String(new Date().getFullYear()),
-  String(new Date().getMonth() + 1),
-);
+// const { start, end } = date.getOneMonthRange(
+//   String(new Date().getFullYear()),
+//   String(new Date().getMonth() + 1),
+// );
 
 const MainPage = () => {
   useEffect(() => {
-    TransactionStore.setFilter(new Date(start), new Date(end), null);
+    // TransactionStore.setFilter(new Date(start), new Date(end), null);
     TransactionStore.loadTransactions();
   }, []);
 
   const SubHeaderBar = (
     <MonthInfo
       month={toJS(TransactionStore.dates.startDate.getMonth() + 1)}
-      total={calTotalPrices(toJS(TransactionStore.transactions))}
+      total={TransactionStore.totalPrices}
     />
   );
 

--- a/fe/src/pages/MainPage/index.tsx
+++ b/fe/src/pages/MainPage/index.tsx
@@ -7,17 +7,10 @@ import Header from 'components/organisms/HeaderBar';
 import FilterBar from 'components/organisms/FilterBar';
 import MonthInfo from 'components/organisms/MonthInfoHeader';
 import NavBarComponent from 'components/organisms/NavBar';
-// import date from 'utils/date';
 import TransactionDateList from './TransactionDateList';
-
-// const { start, end } = date.getOneMonthRange(
-//   String(new Date().getFullYear()),
-//   String(new Date().getMonth() + 1),
-// );
 
 const MainPage = () => {
   useEffect(() => {
-    // TransactionStore.setFilter(new Date(start), new Date(end), null);
     TransactionStore.loadTransactions();
   }, []);
 

--- a/fe/src/pages/MainPage/index.tsx
+++ b/fe/src/pages/MainPage/index.tsx
@@ -28,10 +28,7 @@ const MainPage = () => {
     </div>
   );
 
-  if (
-    'message' in TransactionStore.transactions &&
-    toJS(TransactionStore.transactions.message) === 'nodata'
-  ) {
+  if (toJS(TransactionStore.transactions).length === 0) {
     return (
       <Template
         HeaderBar={<Header />}

--- a/fe/src/pages/StatisticsPage/index.tsx
+++ b/fe/src/pages/StatisticsPage/index.tsx
@@ -6,7 +6,6 @@ import Template from 'components/templates/MainTemplate';
 import Header from 'components/organisms/HeaderBar';
 import MonthInfo from 'components/organisms/MonthInfoHeader';
 import NavBarComponent from 'components/organisms/NavBar';
-import { calTotalPrices } from 'stores/Transaction/transactionStoreUtils';
 import useStatistics from 'hooks/useStatistics';
 import PieChartOverview from 'components/organisms/PieChartOverview';
 
@@ -15,7 +14,7 @@ const StatisticsPage = () => {
   const SubHeaderBar = (
     <MonthInfo
       month={toJS(TransactionStore.dates.startDate.getMonth() + 1)}
-      total={calTotalPrices(toJS(TransactionStore.transactions))}
+      total={TransactionStore.totalPrices}
     />
   );
 

--- a/fe/src/stores/Transaction/index.ts
+++ b/fe/src/stores/Transaction/index.ts
@@ -78,6 +78,11 @@ export const TransactionStore = makeAutoObservable({
     };
   },
   get totalPrices() {
+    if (this.state === state.PENDING) {
+      // TODO PENDING 일 때 0,0을 보여주면 잠시 깜빡거림
+      // 로딩관련 글씨를 보여주면 좋을 듯
+      return { income: 0, expense: 0 };
+    }
     return calTotalPrices(this.transactions);
   },
   async loadTransactions() {

--- a/fe/src/stores/Transaction/index.ts
+++ b/fe/src/stores/Transaction/index.ts
@@ -20,7 +20,7 @@ export interface ITransactionStore {
   };
 }
 
-const { startDate, endDate } = date.getOneMonthRange(
+const oneMonthDate = date.getOneMonthRange(
   String(new Date().getFullYear()),
   String(new Date().getMonth() + 1),
 );
@@ -28,8 +28,8 @@ const { startDate, endDate } = date.getOneMonthRange(
 const initialState: ITransactionStore = {
   transactions: testAccountDateList,
   dates: {
-    startDate,
-    endDate,
+    startDate: oneMonthDate.startDate,
+    endDate: oneMonthDate.endDate,
   },
   filter: {
     methods: [],

--- a/fe/src/stores/Transaction/index.ts
+++ b/fe/src/stores/Transaction/index.ts
@@ -20,7 +20,7 @@ export interface ITransactionStore {
   };
 }
 
-const { start, end } = date.getOneMonthRange(
+const { startDate, endDate } = date.getOneMonthRange(
   String(new Date().getFullYear()),
   String(new Date().getMonth() + 1),
 );
@@ -28,8 +28,8 @@ const { start, end } = date.getOneMonthRange(
 const initialState: ITransactionStore = {
   transactions: testAccountDateList,
   dates: {
-    startDate: new Date(start),
-    endDate: new Date(end),
+    startDate,
+    endDate,
   },
   filter: {
     methods: [],

--- a/fe/src/stores/Transaction/index.ts
+++ b/fe/src/stores/Transaction/index.ts
@@ -53,7 +53,7 @@ const state = {
 };
 
 export const TransactionStore = makeAutoObservable({
-  transactions: { message: 'nodata' } as any,
+  transactions: [] as any,
   dates: initialState.dates,
   filter: initialState.filter,
   state: state.PENDING,

--- a/fe/src/stores/Transaction/index.ts
+++ b/fe/src/stores/Transaction/index.ts
@@ -2,6 +2,7 @@ import { makeAutoObservable, runInAction } from 'mobx';
 import transactionAPI from 'apis/transaction';
 import date from 'utils/date';
 import * as types from 'types';
+import { calTotalPrices } from 'stores/Transaction/transactionStoreUtils';
 import { testAccountDateList } from './testData';
 
 export interface ITransactionStore {
@@ -75,6 +76,9 @@ export const TransactionStore = makeAutoObservable({
       startDate: date.dateFormatter(this.dates.startDate),
       endDate: date.dateFormatter(this.dates.endDate),
     };
+  },
+  get totalPrices() {
+    return calTotalPrices(this.transactions);
   },
   async loadTransactions() {
     this.state = state.PENDING;

--- a/fe/src/utils/date.ts
+++ b/fe/src/utils/date.ts
@@ -9,13 +9,13 @@ export default {
   getOneMonthRange: (year: string, month: string) => {
     if (month === '12') {
       return {
-        start: `${year}-${month}`,
-        end: `${Number(year) + 1}-${1}`,
+        startDate: new Date(`${year}-${month}`),
+        endDate: new Date(`${Number(year) + 1}-${1}`),
       };
     }
     return {
-      start: `${year}-${month}`,
-      end: `${year}-${Number(month) + 1}`,
+      startDate: new Date(`${year}-${month}`),
+      endDate: new Date(`${year}-${Number(month) + 1}`),
     };
   },
   getNextDate: (date: Date | string) =>


### PR DESCRIPTION
## 변경사항 
기존에 데이터가 없을 때 { message: 'nodata' } 로 BE에서 응답하던걸 
빈 배열 return 후 204 상태코드를 띄우도록 수정했습니다.

[이번 PR 변경사항](https://github.com/boostcamp-2020/Project16-A-Account-Book/pull/134/files/8cff073c5064a85cae0b64db5b4884b76d8ce73d..d7d303f478e49779294596f7c2433c209505d007)
## 체크리스트
- [ ] nodata로 처리했던 부분 빈 배열로 바꾸기

## Linked Issues
closes #125

## 멘토님들
@boostcamp-2020/accountbook_mentor
