### PR TITLE
달력 페이지에서 한 달력이 데이터가 없을 때 빈 달력 출력하도록 수정 및 빈 페이지 추가

### DIFF
--- a/fe/src/components/organisms/Calender/index.stories.tsx
+++ b/fe/src/components/organisms/Calender/index.stories.tsx
@@ -93,7 +93,11 @@ const testAccountDateList = {
 export const SundayStart = () => {
   return (
     <GlobalThemeProvider>
-      <Calender isSundayStart transactions={testAccountDateList} />
+      <Calender
+        isSundayStart
+        selectedDate={new Date('2020-11')}
+        transactions={testAccountDateList}
+      />
     </GlobalThemeProvider>
   );
 };
@@ -101,7 +105,19 @@ export const SundayStart = () => {
 export const MondayStart = () => {
   return (
     <GlobalThemeProvider>
-      <Calender isSundayStart={false} transactions={testAccountDateList} />
+      <Calender
+        isSundayStart={false}
+        selectedDate={new Date('2020-11')}
+        transactions={testAccountDateList}
+      />
+    </GlobalThemeProvider>
+  );
+};
+
+export const Empty = () => {
+  return (
+    <GlobalThemeProvider>
+      <Calender isSundayStart selectedDate={new Date('2020-11')} />
     </GlobalThemeProvider>
   );
 };

--- a/fe/src/components/organisms/CalenderBind/index.stories.tsx
+++ b/fe/src/components/organisms/CalenderBind/index.stories.tsx
@@ -97,51 +97,52 @@ const testAccountDateList = {
       __v: 0,
     },
   ],
-  '2020-11-12': [
-    {
-      excludeFromBudget: false,
-      _id: 'aaa',
-      client: '삼겹살',
-      date: '2020-11-12T00:00:00.000Z',
-      memo: '1일메모',
-      method: {
-        _id: 'naver',
-        title: '네이버페이',
-        __v: 0,
-      },
-      category: {
-        _id: 'incomeid',
-        type: 'INCOME',
-        title: '식사',
-        color: '#102e94',
-        __v: 0,
-      },
-      price: 10000,
-      __v: 0,
-    },
+  // '2020-11': [],
+  // '2020-11-12': [
+  //   {
+  //     excludeFromBudget: false,
+  //     _id: 'aaa',
+  //     client: '삼겹살',
+  //     date: '2020-11-12T00:00:00.000Z',
+  //     memo: '1일메모',
+  //     method: {
+  //       _id: 'naver',
+  //       title: '네이버페이',
+  //       __v: 0,
+  //     },
+  //     category: {
+  //       _id: 'incomeid',
+  //       type: 'INCOME',
+  //       title: '식사',
+  //       color: '#102e94',
+  //       __v: 0,
+  //     },
+  //     price: 10000,
+  //     __v: 0,
+  //   },
 
-    {
-      excludeFromBudget: false,
-      _id: 'bbb',
-      client: '삼겹살d',
-      date: '2020-11-12T00:20:00.000Z',
-      memo: '1일메모',
-      method: {
-        _id: 'naver',
-        title: '네이버페이',
-        __v: 0,
-      },
-      category: {
-        _id: 'incomeid',
-        type: 'EXPENSE',
-        title: '식사',
-        color: '#102e94',
-        __v: 0,
-      },
-      price: 10000,
-      __v: 0,
-    },
-  ],
+  //   {
+  //     excludeFromBudget: false,
+  //     _id: 'bbb',
+  //     client: '삼겹살d',
+  //     date: '2020-11-12T00:20:00.000Z',
+  //     memo: '1일메모',
+  //     method: {
+  //       _id: 'naver',
+  //       title: '네이버페이',
+  //       __v: 0,
+  //     },
+  //     category: {
+  //       _id: 'incomeid',
+  //       type: 'EXPENSE',
+  //       title: '식사',
+  //       color: '#102e94',
+  //       __v: 0,
+  //     },
+  //     price: 10000,
+  //     __v: 0,
+  //   },
+  // ],
   '2020-12-12': [
     {
       excludeFromBudget: false,
@@ -164,7 +165,6 @@ const testAccountDateList = {
       price: 10000,
       __v: 0,
     },
-
     {
       excludeFromBudget: false,
       _id: 'bbb',
@@ -187,12 +187,109 @@ const testAccountDateList = {
       __v: 0,
     },
   ],
+  '2021-2-12': [
+    {
+      excludeFromBudget: false,
+      _id: 'aaa',
+      client: '삼겹살',
+      date: '2021-02-12T00:01111.000Z',
+      memo: '1일메모',
+      method: {
+        _id: 'naver',
+        title: '네이버페이',
+        __v: 0,
+      },
+      category: {
+        _id: 'incomeid',
+        type: 'INCOME',
+        title: '식사',
+        color: '#102e94',
+        __v: 0,
+      },
+      price: 10000,
+      __v: 0,
+    },
+
+    {
+      excludeFromBudget: false,
+      _id: 'bbb',
+      client: '삼겹살d',
+      date: '2021-02-12T00:21:00.000Z',
+      memo: '1일메모',
+      method: {
+        _id: 'naver',
+        title: '네이버페이',
+        __v: 0,
+      },
+      category: {
+        _id: 'incomeid',
+        type: 'EXPENSE',
+        title: '식사',
+        color: '#102e94',
+        __v: 0,
+      },
+      price: 10000,
+      __v: 0,
+    },
+  ],
+  '2021-2-13': [
+    {
+      excludeFromBudget: false,
+      _id: 'aaa',
+      client: '삼겹살',
+      date: '2021-02-13T00:01111.000Z',
+      memo: '1일메모',
+      method: {
+        _id: 'naver',
+        title: '네이버페이',
+        __v: 0,
+      },
+      category: {
+        _id: 'incomeid',
+        type: 'INCOME',
+        title: '식사',
+        color: '#102e94',
+        __v: 0,
+      },
+      price: 10000,
+      __v: 0,
+    },
+
+    {
+      excludeFromBudget: false,
+      _id: 'bbb',
+      client: '삼겹살d',
+      date: '2021-02-13T00:21:00.000Z',
+      memo: '1일메모',
+      method: {
+        _id: 'naver',
+        title: '네이버페이',
+        __v: 0,
+      },
+      category: {
+        _id: 'incomeid',
+        type: 'EXPENSE',
+        title: '식사',
+        color: '#102e94',
+        __v: 0,
+      },
+      price: 10000,
+      __v: 0,
+    },
+  ],
 };
 
 export const SundayStart = () => {
   return (
     <GlobalThemeProvider>
-      <CalenderBind isSundayStart transactions={testAccountDateList} />
+      <CalenderBind
+        isSundayStart
+        transactions={testAccountDateList}
+        selectedDate={{
+          startDate: new Date('2020-10-01'),
+          endDate: new Date('2021-06-30'),
+        }}
+      />
     </GlobalThemeProvider>
   );
 };
@@ -200,7 +297,14 @@ export const SundayStart = () => {
 export const MondayStart = () => {
   return (
     <GlobalThemeProvider>
-      <CalenderBind isSundayStart={false} transactions={testAccountDateList} />
+      <CalenderBind
+        isSundayStart={false}
+        transactions={testAccountDateList}
+        selectedDate={{
+          startDate: new Date('2020-10-01'),
+          endDate: new Date('2021-06-30'),
+        }}
+      />
     </GlobalThemeProvider>
   );
 };

--- a/fe/src/components/organisms/CalenderBind/index.stories.tsx
+++ b/fe/src/components/organisms/CalenderBind/index.stories.tsx
@@ -97,52 +97,7 @@ const testAccountDateList = {
       __v: 0,
     },
   ],
-  // '2020-11': [],
-  // '2020-11-12': [
-  //   {
-  //     excludeFromBudget: false,
-  //     _id: 'aaa',
-  //     client: '삼겹살',
-  //     date: '2020-11-12T00:00:00.000Z',
-  //     memo: '1일메모',
-  //     method: {
-  //       _id: 'naver',
-  //       title: '네이버페이',
-  //       __v: 0,
-  //     },
-  //     category: {
-  //       _id: 'incomeid',
-  //       type: 'INCOME',
-  //       title: '식사',
-  //       color: '#102e94',
-  //       __v: 0,
-  //     },
-  //     price: 10000,
-  //     __v: 0,
-  //   },
 
-  //   {
-  //     excludeFromBudget: false,
-  //     _id: 'bbb',
-  //     client: '삼겹살d',
-  //     date: '2020-11-12T00:20:00.000Z',
-  //     memo: '1일메모',
-  //     method: {
-  //       _id: 'naver',
-  //       title: '네이버페이',
-  //       __v: 0,
-  //     },
-  //     category: {
-  //       _id: 'incomeid',
-  //       type: 'EXPENSE',
-  //       title: '식사',
-  //       color: '#102e94',
-  //       __v: 0,
-  //     },
-  //     price: 10000,
-  //     __v: 0,
-  //   },
-  // ],
   '2020-12-12': [
     {
       excludeFromBudget: false,

--- a/fe/src/components/organisms/CalenderBind/index.tsx
+++ b/fe/src/components/organisms/CalenderBind/index.tsx
@@ -39,6 +39,10 @@ const pushEmptyCalender = (
   return localNowSelectedDate;
 };
 
+const dateToYearMonth = (date: Date) => {
+  return `${date.getFullYear()}-${date.getMonth() + 1}`;
+};
+
 const CalenderBind = ({
   isSundayStart,
   transactions = {},
@@ -49,12 +53,8 @@ const CalenderBind = ({
   let nowKey = '';
   let nowYearMonthKey = '';
   let nowTransactions: any = {};
-  let nowSelectedDate = `${selectedDate.startDate.getFullYear()}-${
-    selectedDate.startDate.getMonth() + 1
-  }`;
-  const endDateString = `${selectedDate.endDate.getFullYear()}-${
-    selectedDate.endDate.getMonth() + 1
-  }`;
+  let nowSelectedDate = dateToYearMonth(selectedDate.startDate);
+  const endDateString = dateToYearMonth(selectedDate.endDate);
   Object.entries(transactions).forEach((el) => {
     const [key, value] = el;
     const [year, month] = key.split('-');

--- a/fe/src/components/organisms/CalenderBind/index.tsx
+++ b/fe/src/components/organisms/CalenderBind/index.tsx
@@ -4,47 +4,124 @@ import * as S from './style';
 interface Props {
   isSundayStart: boolean;
   transactions: any;
+  selectedDate: {
+    startDate: Date;
+    endDate: Date;
+  };
 }
+
+const nextMonth = (dateString: string) => {
+  const [year, month] = dateString.split('-');
+  if (Number(month) === 12) {
+    return `${Number(year) + 1}-1`;
+  }
+  return `${year}-${Number(month) + 1}`;
+};
+
+const pushEmptyCalender = (
+  yearMonthKey: string,
+  nowSelectedDate: string,
+  nowTransactions: any,
+  endDateString: string,
+  Calenders: any,
+): string => {
+  let localNowSelectedDate = nowSelectedDate;
+  while (
+    yearMonthKey !== localNowSelectedDate &&
+    JSON.stringify(nowTransactions) === '{}'
+  ) {
+    if (endDateString === localNowSelectedDate) {
+      return 'end';
+    }
+    Calenders.push({ nowYearMonthKey: `${localNowSelectedDate}` });
+    localNowSelectedDate = nextMonth(localNowSelectedDate);
+  }
+  return localNowSelectedDate;
+};
 
 const CalenderBind = ({
   isSundayStart,
   transactions = {},
+  selectedDate,
   ...props
 }: Props): React.ReactElement => {
   const Calenders: Array<any> = [];
   let nowKey = '';
   let nowYearMonthKey = '';
   let nowTransactions: any = {};
+  let nowSelectedDate = `${selectedDate.startDate.getFullYear()}-${
+    selectedDate.startDate.getMonth() + 1
+  }`;
+  const endDateString = `${selectedDate.endDate.getFullYear()}-${
+    selectedDate.endDate.getMonth() + 1
+  }`;
   Object.entries(transactions).forEach((el) => {
     const [key, value] = el;
     const [year, month] = key.split('-');
     const yearMonthKey = `${year}-${month}`;
+
+    nowSelectedDate = pushEmptyCalender(
+      yearMonthKey,
+      nowSelectedDate,
+      nowTransactions,
+      endDateString,
+      Calenders,
+    );
+
+    if (nowSelectedDate === 'end') {
+      return;
+    }
+
     if (nowKey === '') {
       nowKey = key;
       nowYearMonthKey = yearMonthKey;
     }
 
     if (nowYearMonthKey !== yearMonthKey) {
+      nowSelectedDate = nextMonth(nowSelectedDate);
+      Calenders.push({ transactions: { ...nowTransactions }, nowYearMonthKey });
       nowYearMonthKey = yearMonthKey;
       nowKey = key;
-      Calenders.push({ ...nowTransactions });
       nowTransactions = {};
+
+      nowSelectedDate = pushEmptyCalender(
+        yearMonthKey,
+        nowSelectedDate,
+        nowTransactions,
+        endDateString,
+        Calenders,
+      );
+      if (nowSelectedDate === 'end') {
+        return;
+      }
     }
     nowTransactions[key] = value;
   });
-  if (nowTransactions.length !== 0) {
-    Calenders.push({ ...nowTransactions });
+  if (JSON.stringify(nowTransactions) !== '{}') {
+    Calenders.push({ transactions: { ...nowTransactions }, nowYearMonthKey });
+    nowSelectedDate = nextMonth(nowSelectedDate);
+    nowTransactions = {};
+  }
+  while (endDateString !== nowSelectedDate && nowSelectedDate !== 'end') {
+    if (nowSelectedDate === 'end') {
+      break;
+    }
+    if (endDateString === nowSelectedDate) {
+      break;
+    }
+    Calenders.push({ nowYearMonthKey: `${nowSelectedDate}` });
+    nowSelectedDate = nextMonth(nowSelectedDate);
   }
   const CalenderComponents = Calenders.map((el: any) => {
     return (
       <S.Calender
         key={JSON.stringify(el)}
         isSundayStart={isSundayStart}
-        transactions={el}
+        transactions={el.transactions}
+        selectedDate={new Date(el.nowYearMonthKey)}
       />
     );
   });
-
   return <S.CalenderBind {...props}>{CalenderComponents}</S.CalenderBind>;
 };
 

--- a/fe/src/components/organisms/NoData/index.tsx
+++ b/fe/src/components/organisms/NoData/index.tsx
@@ -1,0 +1,8 @@
+import React from 'react';
+import * as S from './style';
+
+const Nodata = ({ ...props }): React.ReactElement => {
+  return <S.NoData {...props}>데이터가 없습니다.</S.NoData>;
+};
+
+export default Nodata;

--- a/fe/src/components/organisms/NoData/style.ts
+++ b/fe/src/components/organisms/NoData/style.ts
@@ -1,0 +1,5 @@
+import styled from 'styled-components';
+
+export const NoData = styled.div``;
+
+export default {};

--- a/fe/src/pages/CalenderPage/index.tsx
+++ b/fe/src/pages/CalenderPage/index.tsx
@@ -7,6 +7,7 @@ import Header from 'components/organisms/HeaderBar';
 import MonthInfo from 'components/organisms/MonthInfoHeader';
 import CalenderBind from 'components/organisms/CalenderBind';
 import NavBarComponent from 'components/organisms/NavBar';
+import NoData from 'components/organisms/NoData';
 
 const CalenderPage = () => {
   useEffect(() => {
@@ -19,13 +20,19 @@ const CalenderPage = () => {
       total={TransactionStore.totalPrices}
     />
   );
+  const selectedDate = {
+    startDate: toJS(TransactionStore.dates.startDate),
+    endDate: toJS(TransactionStore.dates.endDate),
+  };
 
   if (toJS(TransactionStore.transactions).length === 0) {
+    const ContentsComponent = <NoData />;
+
     return (
       <Template
         HeaderBar={<Header />}
         SubHeaderBar={SubHeaderBar}
-        Contents={<CalenderBind isSundayStart transactions={[]} />}
+        Contents={ContentsComponent}
         NavBar={<NavBarComponent />}
       />
     );
@@ -36,6 +43,7 @@ const CalenderPage = () => {
       <CalenderBind
         isSundayStart
         transactions={toJS(TransactionStore.transactions)}
+        selectedDate={selectedDate}
       />
     </>
   );

--- a/fe/src/pages/MainPage/index.tsx
+++ b/fe/src/pages/MainPage/index.tsx
@@ -7,6 +7,7 @@ import Header from 'components/organisms/HeaderBar';
 import FilterBar from 'components/organisms/FilterBar';
 import MonthInfo from 'components/organisms/MonthInfoHeader';
 import NavBarComponent from 'components/organisms/NavBar';
+import NoData from 'components/organisms/NoData';
 import TransactionDateList from './TransactionDateList';
 
 const MainPage = () => {
@@ -29,11 +30,17 @@ const MainPage = () => {
   );
 
   if (toJS(TransactionStore.transactions).length === 0) {
+    const ContentsComponent = (
+      <>
+        <FilterBar />
+        <NoData />
+      </>
+    );
     return (
       <Template
         HeaderBar={<Header />}
         SubHeaderBar={SubHeaderBar}
-        Contents={<FilterBar />}
+        Contents={ContentsComponent}
         NavBar={<NavBarComponent />}
       />
     );

--- a/fe/src/utils/date.ts
+++ b/fe/src/utils/date.ts
@@ -9,12 +9,12 @@ export default {
   getOneMonthRange: (year: string, month: string) => {
     if (month === '12') {
       return {
-        startDate: new Date(`${year}-${month}`),
+        startDate: new Date(`${year}-${month}-1`),
         endDate: new Date(`${Number(year) + 1}-${1}`),
       };
     }
     return {
-      startDate: new Date(`${year}-${month}`),
+      startDate: new Date(`${year}-${month}-1`),
       endDate: new Date(`${year}-${Number(month) + 1}`),
     };
   },


### PR DESCRIPTION
## 변경사항 
### 빈 달력 추가
![rangeCalendar](https://user-images.githubusercontent.com/34783156/101332283-6b48c080-38b8-11eb-9be7-4565c3aca68e.gif)
기존 : 데이터가 없으면 그 해당 달의 달력을 표시하지 않음
개선 : 선택된 기간동안 데이터가 없으면 빈 달력을 표시

### 빈 페이지 추가
데이터가 하나도 없을 때 표시할 NoData 컴포넌트 생성. 추후에 디자인 필요

## 체크리스트
## 목표
- [x] 데이터가 없을 때 빈 달력 추가하는지

## Linked Issues
closes #126 

## 멘토님들
@boostcamp-2020/accountbook_mentor
