### PR TITLE
하나의 거래내역 가져오는 API 추가

### DIFF
--- a/be/src/app.ts
+++ b/be/src/app.ts
@@ -13,9 +13,8 @@ app.use(async (ctx, next) => {
   try {
     await next();
   } catch (err) {
-    err.status = err.status || 500;
+    ctx.status = err.status || 500;
     ctx.body = err.message;
-    ctx.status = err.status;
   }
 });
 app.use(cors(corsOptions));

--- a/be/src/controllers/transaction/index.ts
+++ b/be/src/controllers/transaction/index.ts
@@ -9,11 +9,7 @@ const getTransactionList = async (ctx: Koa.Context) => {
     endDate,
     accountObjId,
   });
-  if (res.length === 0) {
-    ctx.status = 204;
-  } else {
-    ctx.status = 200;
-  }
+  ctx.status = res.length === 0 ? 204 : 200;
   ctx.body = res;
 };
 

--- a/be/src/controllers/transaction/index.ts
+++ b/be/src/controllers/transaction/index.ts
@@ -1,4 +1,5 @@
 import Koa from 'koa';
+import { invalidTransactionError } from 'libs/error';
 import * as service from 'services/transaction';
 
 const getTransactionList = async (ctx: Koa.Context) => {
@@ -19,8 +20,7 @@ const getTransaction = async (ctx: Koa.Context) => {
     const transaction = await service.getTransaction(transactionObjId);
     ctx.body = transaction;
   } catch (e) {
-    e.status = 400;
-    throw e;
+    throw invalidTransactionError;
   }
 };
 

--- a/be/src/controllers/transaction/index.ts
+++ b/be/src/controllers/transaction/index.ts
@@ -1,10 +1,14 @@
 import Koa from 'koa';
-import { getTransaction, saveAndAddToAccount } from 'services/transaction';
+import * as service from 'services/transaction';
 
-const get = async (ctx: Koa.Context) => {
+const getTransactionList = async (ctx: Koa.Context) => {
   const { startDate, endDate } = ctx.query;
   const { accountObjId } = ctx.params;
-  const res = await getTransaction({ startDate, endDate, accountObjId });
+  const res = await service.getTransactionList({
+    startDate,
+    endDate,
+    accountObjId,
+  });
   if (res.length === 0) {
     ctx.status = 204;
   } else {
@@ -17,7 +21,7 @@ const post = async (ctx: Koa.Context) => {
   const { transaction } = ctx.request.body;
   const { accountObjId } = ctx.params;
   try {
-    await saveAndAddToAccount(transaction, accountObjId);
+    await service.saveAndAddToAccount(transaction, accountObjId);
   } catch (e) {
     e.status = 400;
     throw e;
@@ -26,4 +30,4 @@ const post = async (ctx: Koa.Context) => {
   ctx.res.end();
 };
 
-export default { get, post };
+export default { getTransactionList, post };

--- a/be/src/controllers/transaction/index.ts
+++ b/be/src/controllers/transaction/index.ts
@@ -13,6 +13,17 @@ const getTransactionList = async (ctx: Koa.Context) => {
   ctx.body = res;
 };
 
+const getTransaction = async (ctx: Koa.Context) => {
+  const { transactionObjId } = ctx.params;
+  try {
+    const transaction = await service.getTransaction(transactionObjId);
+    ctx.body = transaction;
+  } catch (e) {
+    e.status = 400;
+    throw e;
+  }
+};
+
 const post = async (ctx: Koa.Context) => {
   const { transaction } = ctx.request.body;
   const { accountObjId } = ctx.params;
@@ -26,4 +37,4 @@ const post = async (ctx: Koa.Context) => {
   ctx.res.end();
 };
 
-export default { getTransactionList, post };
+export default { getTransactionList, post, getTransaction };

--- a/be/src/libs/error.ts
+++ b/be/src/libs/error.ts
@@ -1,0 +1,5 @@
+export default {};
+export const invalidTransactionError = {
+  status: 400,
+  message: '잘못된 Transaction Id이거나, 삭제된 Transaction에 접근하였습니다.',
+};

--- a/be/src/models/transaction/index.ts
+++ b/be/src/models/transaction/index.ts
@@ -1,5 +1,32 @@
-import { Schema, Types, model, Document } from 'mongoose';
+import { Schema, Types, model, Document, Model } from 'mongoose';
+import { findByPkAndPopulateAll } from './static';
 
+export interface ITransaction {
+  client: string;
+  method: string;
+  category: string;
+  date: Date;
+  price: number;
+  memo?: string;
+  excludeFromBudget?: boolean;
+}
+export interface TransactionDocument extends Document {
+  client: string;
+  method: string;
+  category: string;
+  date: Date;
+  price: number;
+  memo?: string;
+  excludeFromBudget?: boolean;
+}
+
+export interface ITransactionDocument extends ITransaction, Document {}
+
+export interface ITransactionModel extends Model<ITransactionDocument> {
+  findByPkAndPopulateAll(
+    transactionObjId: string,
+  ): Promise<ITransactionDocument>;
+}
 const TransactionSchema = new Schema({
   client: {
     type: String,
@@ -32,19 +59,9 @@ const TransactionSchema = new Schema({
   },
 });
 
-export interface ITransaction {
-  client: string;
-  method: string;
-  category: string;
-  date: Date;
-  price: number;
-  memo?: string;
-  excludeFromBudget?: boolean;
-}
+TransactionSchema.statics.findByPkAndPopulateAll = findByPkAndPopulateAll;
 
-export interface ITransactionDocument extends ITransaction, Document {}
-
-export const TransactionModel = model<ITransactionDocument>(
+export const TransactionModel = model<ITransactionDocument, ITransactionModel>(
   'transactions',
   TransactionSchema,
 );

--- a/be/src/models/transaction/index.ts
+++ b/be/src/models/transaction/index.ts
@@ -9,6 +9,7 @@ export interface ITransaction {
   price: number;
   memo?: string;
   excludeFromBudget?: boolean;
+  isDeleted?: boolean;
 }
 export interface TransactionDocument extends Document {
   client: string;
@@ -18,6 +19,7 @@ export interface TransactionDocument extends Document {
   price: number;
   memo?: string;
   excludeFromBudget?: boolean;
+  isDeleted?: boolean;
 }
 
 export interface ITransactionDocument extends ITransaction, Document {}
@@ -54,6 +56,10 @@ const TransactionSchema = new Schema({
     required: true,
   },
   excludeFromBudget: {
+    type: Boolean,
+    default: 'false',
+  },
+  isDeleted: {
     type: Boolean,
     default: 'false',
   },

--- a/be/src/models/transaction/static.ts
+++ b/be/src/models/transaction/static.ts
@@ -2,7 +2,11 @@ export async function findByPkAndPopulateAll(
   this: any,
   transactionObjId: string,
 ) {
-  const transaction = await this.findById(transactionObjId)
+  const transaction = await this.findOne({
+    _id: transactionObjId,
+    isDeleted: false,
+  })
+    .select('-isDeleted')
     .populate({
       path: 'category method',
     })

--- a/be/src/models/transaction/static.ts
+++ b/be/src/models/transaction/static.ts
@@ -1,0 +1,13 @@
+export async function findByPkAndPopulateAll(
+  this: any,
+  transactionObjId: string,
+) {
+  const transaction = await this.findById(transactionObjId)
+    .populate({
+      path: 'category method',
+    })
+    .exec();
+  return transaction;
+}
+
+export default {};

--- a/be/src/routers/api/transaction/index.ts
+++ b/be/src/routers/api/transaction/index.ts
@@ -3,6 +3,6 @@ import transactionController from 'controllers/transaction';
 
 const router = new Router();
 
-router.get('/:accountObjId', transactionController.get);
+router.get('/:accountObjId', transactionController.getTransactionList);
 router.post('/:accountObjId', transactionController.post);
 export default router;

--- a/be/src/routers/api/transaction/index.ts
+++ b/be/src/routers/api/transaction/index.ts
@@ -3,6 +3,7 @@ import transactionController from 'controllers/transaction';
 
 const router = new Router();
 
+router.get('/:transactionObjId/detail', transactionController.getTransaction);
 router.get('/:accountObjId', transactionController.getTransactionList);
 router.post('/:accountObjId', transactionController.post);
 export default router;

--- a/be/src/seeds/transaction.ts
+++ b/be/src/seeds/transaction.ts
@@ -34,6 +34,7 @@ export const up = ({ methods, categories }: TransactionType) => {
           start: 1000,
           end: 300000,
         });
+        const isDeleted = index % 5 === 0;
         transactionList.push({
           client,
           date,
@@ -41,6 +42,7 @@ export const up = ({ methods, categories }: TransactionType) => {
           method,
           category,
           price,
+          isDeleted,
         });
         return transactionList;
       }, []);

--- a/be/src/services/transaction/index.ts
+++ b/be/src/services/transaction/index.ts
@@ -12,7 +12,7 @@ const oneMonthTransactionsReducer = (acc: any, transaction: ITransaction) => {
     : { ...acc, [key]: [transaction] };
 };
 
-export const getTransaction = async ({
+export const getTransactionList = async ({
   startDate,
   endDate,
   accountObjId,

--- a/be/src/services/transaction/index.ts
+++ b/be/src/services/transaction/index.ts
@@ -59,3 +59,13 @@ export const saveAndAddToAccount = async (
     transcationObjId,
   );
 };
+
+export const getTransaction = async (transactionObjId: string) => {
+  const transaction = await TransactionModel.findByPkAndPopulateAll(
+    transactionObjId,
+  );
+  if (!transaction) {
+    throw new Error('Invalid Transaction Object Id ');
+  }
+  return transaction;
+};

--- a/be/src/services/transaction/index.ts
+++ b/be/src/services/transaction/index.ts
@@ -1,6 +1,5 @@
 import { TransactionModel, ITransaction } from 'models/transaction';
 import { AccountModel } from 'models/account';
-import { categoryType } from 'models/category';
 import { getCompFuncByKey } from 'libs/utils';
 
 const oneMonthTransactionsReducer = (acc: any, transaction: ITransaction) => {
@@ -13,18 +12,6 @@ const oneMonthTransactionsReducer = (acc: any, transaction: ITransaction) => {
     : { ...acc, [key]: [transaction] };
 };
 
-const sumPricesByType = (transactions: Array<any>) => {
-  const initTotalPrice = { income: 0, expense: 0 };
-  const totalPrice = transactions.reduce((sumPrice, transaction) => {
-    if (transaction.category.type === categoryType.EXPENSE) {
-      return { ...sumPrice, expense: sumPrice.expense + transaction.price };
-    }
-    return { ...sumPrice, income: sumPrice.income + transaction.price };
-  }, initTotalPrice);
-  return totalPrice;
-};
-
-const sumPricesByCategory = (transactions: Array<any>) => {};
 export const getTransaction = async ({
   startDate,
   endDate,
@@ -71,18 +58,4 @@ export const saveAndAddToAccount = async (
     accountObjId,
     transcationObjId,
   );
-};
-export const getCategoryStatistics = async (
-  accountObjId: string,
-  startDate: string,
-  endDate: string,
-) => {
-  const transactions = await AccountModel.findByPkAndGetTransCategory(
-    accountObjId,
-    startDate,
-    endDate,
-  );
-  const totalPrice = sumPricesByType(transactions);
-  const categories = sumPricesByCategory(transactions);
-  return { totalPrice };
 };

--- a/be/src/services/transaction/index.ts
+++ b/be/src/services/transaction/index.ts
@@ -65,7 +65,7 @@ export const getTransaction = async (transactionObjId: string) => {
     transactionObjId,
   );
   if (!transaction) {
-    throw new Error('Invalid Transaction Object Id ');
+    throw new Error();
   }
   return transaction;
 };


### PR DESCRIPTION
## 변경사항 
- transaction schema에 isDeleted 필드를 추가하고, 시드 데이터에도 추가하였습니다.
기본값은 false입니다.

- 하나의 거래내역을 가져오는 API의 url은 다음과 같습니다. 
```
/transactions/:transactionObjId/detail
```
- API를 포스트맨 example에 추가하였습니다.
- 잘못된 object id이거나, 삭제된 거래내역에 접근할 시, 400 에러와 다음과 같은 에러 메시지를 띄웁니다.
```
잘못된 Transaction Id이거나, 삭제된 Transaction에 접근하였습니다.
```
- 에러의 status와 message를 libs/error.ts에 추가하였습니다.
```ts
export const invalidTransactionError = {
  status: 400,
  message: '잘못된 Transaction Id이거나, 삭제된 Transaction에 접근하였습니다.',
};
```
## 논의하고 싶은 점
저희가 에러 핸들링에 대한 response 표준화가 안되어 있는 것 같습니다. 
에러일 때의 response 표준화를 정하는 것이 좋지 않을까 생각이 듭니다!

## 체크리스트
- [x] 삭제된 데이터는 가져오지 않는다.
- [x] 필드 중에서 isDeleted는 가져오지 않는다.

## Linked Issues
closes #140 
## 멘토님들
@boostcamp-2020/accountbook_mentor
