### PR TITLE
필터 모달로 변경 

### DIFF
--- a/fe/src/components/atoms/DatePicker/style.ts
+++ b/fe/src/components/atoms/DatePicker/style.ts
@@ -20,6 +20,9 @@ export const Container = styled.div`
     border: none;
     outline: none;
   }
+  input {
+    width: 4em;
+  }
 `;
 
 export const DecsContainer = styled.div`

--- a/fe/src/components/molecules/DateRange/index.tsx
+++ b/fe/src/components/molecules/DateRange/index.tsx
@@ -16,7 +16,7 @@ const DateRange = ({ dates, onChange, disabled = false }: IDateRange) => {
     <S.DecsContainer>
       <div>
         <S.Small>시작일</S.Small>
-        <div>
+        <div className="date-container">
           <DatePicker
             date={dates.startDate}
             name="startDate"
@@ -27,7 +27,7 @@ const DateRange = ({ dates, onChange, disabled = false }: IDateRange) => {
       </div>
       <div>
         <S.Small>마지막일</S.Small>
-        <div>
+        <div className="date-container">
           <DatePicker
             date={dates.endDate}
             name="endDate"

--- a/fe/src/components/molecules/DateRange/style.ts
+++ b/fe/src/components/molecules/DateRange/style.ts
@@ -8,6 +8,10 @@ export const DecsContainer = styled.div`
   padding: 0.5rem 0.3rem;
   background: transparent;
   background: ${({ theme }) => theme.color.white};
+  .date-container {
+    display: flex;
+    justify-content: center;
+  }
 `;
 export const Small = styled.small`
   font-size: 0.8rem;

--- a/fe/src/components/molecules/DropdownBody/style.ts
+++ b/fe/src/components/molecules/DropdownBody/style.ts
@@ -7,16 +7,11 @@ export const CheckBoxContainer = styled.div`
 export const DropdownBodyWrap = styled.div`
   display: flex;
   flex-direction: column;
-  position: absolute;
   background-color: white;
-  width: inherit;
   max-height: 35vh;
   overflow-y: auto;
-  z-index: 10;
   border: 1px solid ${({ theme }) => theme.color.subText};
   padding: 0.3em;
-  top: 1.3rem;
-  left: 0;
   .dropdown-item + .dropdown-item {
     border-top: 1px solid ${({ theme }) => theme.color.subText};
   }
@@ -25,15 +20,9 @@ export const DropdownBodyWrap = styled.div`
     align-items: center;
     border: none;
     padding: 0.5rem;
+    min-width: 10rem;
     background: transparent;
     display: flex;
     color: ${({ theme }) => theme.color.black};
-  }
-  @media only screen and (max-width: 600px) {
-    position: fixed;
-    top: 50%;
-    left: 50%;
-    max-width: 50vw;
-    transform: translate(-50%, -50%);
   }
 `;

--- a/fe/src/components/molecules/DropdownBody/style.ts
+++ b/fe/src/components/molecules/DropdownBody/style.ts
@@ -10,6 +10,8 @@ export const DropdownBodyWrap = styled.div`
   position: absolute;
   background-color: white;
   width: inherit;
+  max-height: 35vh;
+  overflow-y: auto;
   z-index: 10;
   border: 1px solid ${({ theme }) => theme.color.subText};
   padding: 0.3em;
@@ -26,5 +28,12 @@ export const DropdownBodyWrap = styled.div`
     background: transparent;
     display: flex;
     color: ${({ theme }) => theme.color.black};
+  }
+  @media only screen and (max-width: 600px) {
+    position: fixed;
+    top: 50%;
+    left: 50%;
+    max-width: 50vw;
+    transform: translate(-50%, -50%);
   }
 `;

--- a/fe/src/components/molecules/DropdownHeader/index.tsx
+++ b/fe/src/components/molecules/DropdownHeader/index.tsx
@@ -1,5 +1,6 @@
 import React, { useRef } from 'react';
 import useVisible from 'hooks/useVisible';
+import ModalContainer from '../ModalContainer';
 
 import * as S from './style';
 
@@ -19,13 +20,21 @@ const DropdownButtonHeader = ({
 }: Props) => {
   const dropdownContainer = useRef<HTMLDivElement>(null);
   const [visible, toogleVisivle] = useVisible(dropdownContainer);
-
+  const onClickVisible = (e: MouseEvent) => {
+    e.preventDefault();
+    e.stopPropagation();
+    toogleVisivle();
+  };
   return (
-    <S.Container ref={dropdownContainer} border={border}>
-      <S.DropdownButton onClick={toogleVisivle} disabled={disabled}>
+    <S.Container border={border}>
+      <S.DropdownButton onClick={onClickVisible} disabled={disabled}>
         <div>{`${title} ${arrowCharacter}`}</div>
       </S.DropdownButton>
-      {visible && children}
+      {visible && (
+        <ModalContainer>
+          <div ref={dropdownContainer}>{children}</div>
+        </ModalContainer>
+      )}
     </S.Container>
   );
 };

--- a/fe/src/components/organisms/MainFilterForm/style.ts
+++ b/fe/src/components/organisms/MainFilterForm/style.ts
@@ -3,10 +3,9 @@ import Button from 'components/atoms/Button';
 import Input from 'components/atoms/Input';
 
 export const Container = styled.section`
-  position: absolute;
+  position: relative;
   left: 0;
   top: 1.5rem;
-  z-index: 10;
   min-width: 80vw;
   border: 1px solid ${({ theme }) => theme.color.subText};
   background: ${({ theme }) => theme.color.white};
@@ -61,12 +60,9 @@ export const DateContainer = styled.div`
 `;
 
 export const DateFilterContainer = styled.div`
-  position: absolute;
-  width: calc(100% - 0.6em);
   border: 1px solid ${({ theme }) => theme.color.subText};
   padding: 0.3em;
   background: white;
-  z-index: 10;
 `;
 
 export const DateFilterButton = styled(Button)`
@@ -80,17 +76,4 @@ export const DateFilterButton = styled(Button)`
 export const BottomButton = styled(Input)`
   border: none;
   background: ${({ theme }) => theme.color.brandColor};
-`;
-
-export const Model = styled.div`
-  position: fixed;
-  top: 0;
-  left: 0;
-  z-index: 999;
-  width: 100vw;
-  height: 100vh;
-  display: flex;
-  justify-content: center;
-  align-items: center;
-  background: rgba(0, 0, 0, 0.5);
 `;

--- a/fe/src/components/templates/MainTemplate/style.ts
+++ b/fe/src/components/templates/MainTemplate/style.ts
@@ -12,7 +12,6 @@ export const ContentArea = styled.div`
   overflow-y: auto;
   box-sizing: border-box;
   position: absolute;
-  z-index: -1;
   width: 100%;
   top: 3rem;
   height: calc(100vh - 3rem - 4rem - 2px);
@@ -22,7 +21,6 @@ export const ContentArea = styled.div`
 
 export const Header = styled.header`
   position: absolute;
-  z-index: 10;
   top: 0;
   left: 0;
   width: 100%;


### PR DESCRIPTION
## [변경사항](https://github.com/boostcamp-2020/Project16-A-Account-Book/pull/228/files/d5acc4f08fe264ce94b5698759a6471618e44bc8..be9eaca7cee4b880511996ba99ca5a95d23c6327)
![Dec-15-2020 00-09-47](https://user-images.githubusercontent.com/44409642/102097997-f6522980-3e69-11eb-9c7a-70e6fd318cfd.gif)

모달을 적용하여 필터 화면이 중앙에 배치 되도록 하는게 UX가 좋을 것 같아 변경 하였습니다. 
그리고 내부 리스트도 최대 길이를 지정하고 스크롤이 생성되게 하였습니다.
## 멘토님들

@boostcamp-2020/accountbook_mentor
