### PR TITLE
태그 페이지 title 길이 제한 미들웨어 작성 & FE에서 중복 검사 로직 생성

### DIFF
--- a/be/src/controllers/category/index.ts
+++ b/be/src/controllers/category/index.ts
@@ -28,9 +28,10 @@ const getStatisticsInfo = async (ctx: Context) => {
 const post = async (ctx: Context) => {
   const { accountObjId } = ctx.params;
   const { type, title, color } = ctx.request.body;
-  const res = await postCategory(type, title, color, accountObjId);
-  ctx.status = res.success ? 201 : 200;
-  ctx.body = res;
+
+  await postCategory(type, title, color, accountObjId);
+  ctx.status = 201;
+  ctx.res.end();
 };
 
 const put = async (ctx: Context) => {

--- a/be/src/libs/error.ts
+++ b/be/src/libs/error.ts
@@ -48,3 +48,9 @@ export const accountNoChange = {
   status: 400,
   message: 'account Update 중 에러가 발생했습니다.',
 };
+
+export const invaildTitleLengthTitle = {
+  status: 200,
+  error: '최대 20자 까지 입력 가능합니다',
+  success: false,
+};

--- a/be/src/libs/error.ts
+++ b/be/src/libs/error.ts
@@ -54,3 +54,9 @@ export const invaildTitleLengthTitle = {
   error: '최대 20자 까지 입력 가능합니다',
   success: false,
 };
+
+export const duplicatedValue = {
+  status: 200,
+  error: '중복된 입력입니다',
+  success: false,
+};

--- a/be/src/middlewares/index.ts
+++ b/be/src/middlewares/index.ts
@@ -7,6 +7,8 @@ import {
   invalidCategory,
   accountHasNoUserError,
   updateUnclassifiedMethod,
+  invaildMethod,
+  invaildTitleLengthTitle,
 } from 'libs/error';
 import { UserModel } from 'models/user';
 import { CategoryModel, categoryType } from 'models/category';
@@ -83,7 +85,18 @@ export const titleIsUnclassified = async (
   next: () => Promise<any>,
 ) => {
   const { title } = ctx.request.body;
-  if (!title || title.trim() === '' || title.trim() === '미분류')
-    throw updateUnclassifiedMethod;
+  if (!title || title.trim() === '미분류') throw updateUnclassifiedMethod;
+  await next();
+};
+
+export const isVaildLengthTitle = async (
+  ctx: Koa.Context,
+  next: () => Promise<any>,
+) => {
+  const { title } = ctx.request.body;
+  if (!title) throw invaildMethod;
+  const trimedTitle = title.trim();
+  if (trimedTitle.length <= 0 || trimedTitle.length > 20)
+    throw invaildTitleLengthTitle;
   await next();
 };

--- a/be/src/middlewares/index.ts
+++ b/be/src/middlewares/index.ts
@@ -98,5 +98,6 @@ export const isVaildLengthTitle = async (
   const trimedTitle = title.trim();
   if (trimedTitle.length <= 0 || trimedTitle.length > 20)
     throw invaildTitleLengthTitle;
+  ctx.request.body.title = trimedTitle;
   await next();
 };

--- a/be/src/models/account/index.ts
+++ b/be/src/models/account/index.ts
@@ -11,6 +11,7 @@ import {
   findUnclassifiedMethod,
   findAccountByUserId,
   findByPkAndPushUser,
+  findDuplicateCategory,
 } from './static';
 
 export interface IAccount {
@@ -55,6 +56,11 @@ export interface IAccountModel extends Model<IAccountDocument> {
   findUnclassifiedMethod(accountObjId: string): Promise<any>;
   findAccountByUserId(userId: string): Promise<any>;
   findByPkAndPushUser(userObjId: string, accountObjId: string): Promise<any>;
+  findDuplicateCategory(
+    accountObjId: string,
+    type: string,
+    title: string,
+  ): Promise<any>;
 }
 
 export const AccountSchema = new Schema({
@@ -92,6 +98,7 @@ AccountSchema.statics.findAccountByUserId = findAccountByUserId;
 AccountSchema.statics.findByPkAndPushUser = findByPkAndPushUser;
 AccountSchema.statics.findUnclassifiedCategory = findUnclassifiedCategory;
 AccountSchema.statics.findUnclassifiedMethod = findUnclassifiedMethod;
+AccountSchema.statics.findDuplicateCategory = findDuplicateCategory;
 
 export const AccountModel = model<IAccountDocument, IAccountModel>(
   'accounts',

--- a/be/src/models/account/static.ts
+++ b/be/src/models/account/static.ts
@@ -124,3 +124,18 @@ export async function findUnclassifiedCategory(
 
   return res.categories[0]._id;
 }
+
+export async function findDuplicateCategory(
+  this: IAccountModel,
+  accountObjId: string,
+  type: string,
+  title: string,
+) {
+  return AccountModel.findById(accountObjId, {
+    categories: true,
+  }).populate({
+    path: 'categories',
+    match: { type, title },
+    select: '_id',
+  });
+}

--- a/be/src/routers/api/category/index.ts
+++ b/be/src/routers/api/category/index.ts
@@ -1,15 +1,29 @@
 import Router from 'koa-router';
 import koaCompose from 'koa-compose';
 import categoryController from 'controllers/category';
-import { isUnclassifide, titleIsUnclassified } from 'middlewares';
+import {
+  isUnclassifide,
+  titleIsUnclassified,
+  isVaildLengthTitle,
+} from 'middlewares';
 
 const router = new Router();
 
 router.get('/statistics', categoryController.getStatisticsInfo);
 
 router.get('/', categoryController.get);
-router.post('/', koaCompose([titleIsUnclassified, categoryController.post]));
-router.put('/', koaCompose([titleIsUnclassified, categoryController.put]));
+router.post(
+  '/',
+  koaCompose([
+    titleIsUnclassified,
+    isVaildLengthTitle,
+    categoryController.post,
+  ]),
+);
+router.put(
+  '/',
+  koaCompose([titleIsUnclassified, isVaildLengthTitle, categoryController.put]),
+);
 router.delete(
   '/:category',
   koaCompose([isUnclassifide, categoryController.deleteCategory]),

--- a/be/src/routers/api/method/index.ts
+++ b/be/src/routers/api/method/index.ts
@@ -1,16 +1,19 @@
 import Router from 'koa-router';
 import methodController from 'controllers/method';
 import koaCompose from 'koa-compose';
-import { titleIsUnclassified } from 'middlewares';
+import { titleIsUnclassified, isVaildLengthTitle } from 'middlewares';
 
 const router = new Router();
 
 router.get('/', methodController.get);
-router.post('/', koaCompose([titleIsUnclassified, methodController.post]));
+router.post(
+  '/',
+  koaCompose([titleIsUnclassified, isVaildLengthTitle, methodController.post]),
+);
 router.delete('/:methodObjId', methodController.del);
 router.put(
   '/:methodObjId',
-  koaCompose([titleIsUnclassified, methodController.put]),
+  koaCompose([titleIsUnclassified, isVaildLengthTitle, methodController.put]),
 );
 
 export default router;

--- a/be/src/services/category/index.ts
+++ b/be/src/services/category/index.ts
@@ -146,8 +146,8 @@ export const updateCategory = async (
   });
 
   if (
-    String(exist.categories[0]._id) === objId ||
-    exist.categories.length === 0
+    exist.categories.length === 0 ||
+    String(exist.categories[0]._id) === objId
   ) {
     await CategoryModel.update(
       { _id: objId },

--- a/be/src/services/category/index.ts
+++ b/be/src/services/category/index.ts
@@ -2,6 +2,7 @@ import { AccountModel } from 'models/account';
 import { CategoryModel, categoryType } from 'models/category';
 import { TransactionModel } from 'models/transaction';
 import { getCompFuncByKey } from 'libs/utils';
+import { duplicatedValue } from 'libs/error';
 import { ITotalPrice, ICategoryStatistics, IStatistics } from './index.type';
 
 const getSumByCategories = (
@@ -109,25 +110,23 @@ export const postCategory = async (
   color: string,
   accountObjId: string,
 ) => {
-  const res = await CategoryModel.findOne({ title });
-  if (res != null) {
-    return { success: false, error: '중복된 타이틀 존재' };
-  }
+  const exist: any = await AccountModel.findDuplicateCategory(
+    accountObjId,
+    type,
+    title,
+  );
+  if (exist.categories.length !== 0) throw duplicatedValue;
+
   const newCategory = new CategoryModel({
     type,
     title,
     color,
   });
-  try {
-    await newCategory.save();
-    await AccountModel.update(
-      { _id: accountObjId },
-      { $push: { categories: newCategory._id } },
-    );
-    return { success: true, newCategory };
-  } catch (e) {
-    return { success: false, message: e };
-  }
+  const updateAccount = AccountModel.update(
+    { _id: accountObjId },
+    { $push: { categories: newCategory._id } },
+  );
+  return Promise.all([newCategory.save(), updateAccount]);
 };
 
 export const updateCategory = async (
@@ -137,14 +136,11 @@ export const updateCategory = async (
   color: string,
   accountObjId: string,
 ) => {
-  const exist: any = await AccountModel.findById(accountObjId, {
-    categories: true,
-  }).populate({
-    path: 'categories',
-    match: { type, title },
-    select: '_id',
-  });
-
+  const exist: any = await AccountModel.findDuplicateCategory(
+    accountObjId,
+    type,
+    title,
+  );
   if (
     exist.categories.length === 0 ||
     String(exist.categories[0]._id) === objId

--- a/fe/src/components/molecules/CategoryDropdown/style.ts
+++ b/fe/src/components/molecules/CategoryDropdown/style.ts
@@ -32,6 +32,10 @@ export const DropdownBodyWrap = styled.div`
   .title-container {
     margin-right: auto;
     height: 1.5em;
+    width: 100%;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
   }
   .modify-button {
     margin-right: 0.5em;

--- a/fe/src/pages/CategoryPage/index.tsx
+++ b/fe/src/pages/CategoryPage/index.tsx
@@ -92,8 +92,15 @@ function CategoryPage(): React.ReactElement {
     loadStore();
     setDeleteVisible(false);
   };
-
+  const isVaildLengthTitle = (title: string) => {
+    return title && title.length >= 1 && title.length <= 20;
+  };
   const confirm = async () => {
+    const trimedTitle = inputRef.current.value.trim();
+    if (!isVaildLengthTitle(trimedTitle)) {
+      alert('최대 20자까지 입력이 가능합니다.');
+      return;
+    }
     const apiFuc = type === 'METHOD' ? methodConfirm : categoryConfirm;
     const result: any = await apiFuc();
     if (result.error) {
@@ -105,6 +112,15 @@ function CategoryPage(): React.ReactElement {
     }
   };
   const methodConfirm = async () => {
+    const exist = MethodStore.getMethods().find(
+      (method) => method.title === inputRef.current.value.trim(),
+    );
+    if (exist && exist._id === selectedRef.current) {
+      return Promise.resolve({ error: '변경사항이 없습니다!' });
+    }
+    if (exist) {
+      return Promise.resolve({ error: '중복되는 입력입니다!' });
+    }
     const body = {
       title: inputRef.current.value,
     };
@@ -114,6 +130,15 @@ function CategoryPage(): React.ReactElement {
     return func(TransactionStore.accountObjId, body, selectedRef.current);
   };
   const categoryConfirm = async () => {
+    const exist = CategoryStore.getCategories(type).find(
+      (category) => category.title === inputRef.current.value.trim(),
+    );
+    if (exist && exist._id === selectedRef.current) {
+      return Promise.resolve({ error: '변경사항이 없습니다!' });
+    }
+    if (exist) {
+      return Promise.resolve({ error: '중복되는 입력입니다!' });
+    }
     const body = {
       type,
       title: inputRef.current.value,
@@ -128,10 +153,12 @@ function CategoryPage(): React.ReactElement {
 
   const onCancle = (fnc: any) => () => {
     inputRef.current.value = '';
+    selectedRef.current = '';
     fnc(false);
   };
 
   const onPlusButtonClick = () => {
+    inputRef.current.value = '';
     colorPicker.current.value = getRandomColor();
     setVisible(true);
   };


### PR DESCRIPTION
## [변경사항](https://github.com/boostcamp-2020/Project16-A-Account-Book/pull/229/files/be9eaca7cee4b880511996ba99ca5a95d23c6327..82b68cb73ebd8913d9e1085e21fa110be4ace282)
길이가 길어질 경우 레이아웃에 영향이 있을 것으로 추정이 되어 길이를 20자로 제한하는 미들웨어를 추가 하였습니다. 
그리고 서버에 요청 전 FE에서 중복 검사하는 로직을 추가하여 API 요청을 줄였습니다. 

## 멘토님들

@boostcamp-2020/accountbook_mentor
