### PR TITLE
거래내역 생성 페이지 스타일 수정

### DIFF
--- a/be/src/controllers/category/index.ts
+++ b/be/src/controllers/category/index.ts
@@ -28,9 +28,10 @@ const getStatisticsInfo = async (ctx: Context) => {
 const post = async (ctx: Context) => {
   const { accountObjId } = ctx.params;
   const { type, title, color } = ctx.request.body;
-  const res = await postCategory(type, title, color, accountObjId);
-  ctx.status = res.success ? 201 : 200;
-  ctx.body = res;
+
+  await postCategory(type, title, color, accountObjId);
+  ctx.status = 201;
+  ctx.res.end();
 };
 
 const put = async (ctx: Context) => {

--- a/be/src/libs/error.ts
+++ b/be/src/libs/error.ts
@@ -48,3 +48,9 @@ export const accountNoChange = {
   status: 400,
   message: 'account Update 중 에러가 발생했습니다.',
 };
+
+export const invaildTitleLengthTitle = {
+  status: 200,
+  error: '최대 20자 까지 입력 가능합니다',
+  success: false,
+};

--- a/be/src/libs/error.ts
+++ b/be/src/libs/error.ts
@@ -54,3 +54,9 @@ export const invaildTitleLengthTitle = {
   error: '최대 20자 까지 입력 가능합니다',
   success: false,
 };
+
+export const duplicatedValue = {
+  status: 200,
+  error: '중복된 입력입니다',
+  success: false,
+};

--- a/be/src/middlewares/index.ts
+++ b/be/src/middlewares/index.ts
@@ -7,6 +7,8 @@ import {
   invalidCategory,
   accountHasNoUserError,
   updateUnclassifiedMethod,
+  invaildMethod,
+  invaildTitleLengthTitle,
 } from 'libs/error';
 import { UserModel } from 'models/user';
 import { CategoryModel, categoryType } from 'models/category';
@@ -83,7 +85,18 @@ export const titleIsUnclassified = async (
   next: () => Promise<any>,
 ) => {
   const { title } = ctx.request.body;
-  if (!title || title.trim() === '' || title.trim() === '미분류')
-    throw updateUnclassifiedMethod;
+  if (!title || title.trim() === '미분류') throw updateUnclassifiedMethod;
+  await next();
+};
+
+export const isVaildLengthTitle = async (
+  ctx: Koa.Context,
+  next: () => Promise<any>,
+) => {
+  const { title } = ctx.request.body;
+  if (!title) throw invaildMethod;
+  const trimedTitle = title.trim();
+  if (trimedTitle.length <= 0 || trimedTitle.length > 20)
+    throw invaildTitleLengthTitle;
   await next();
 };

--- a/be/src/middlewares/index.ts
+++ b/be/src/middlewares/index.ts
@@ -98,5 +98,6 @@ export const isVaildLengthTitle = async (
   const trimedTitle = title.trim();
   if (trimedTitle.length <= 0 || trimedTitle.length > 20)
     throw invaildTitleLengthTitle;
+  ctx.request.body.title = trimedTitle;
   await next();
 };

--- a/be/src/models/account/index.ts
+++ b/be/src/models/account/index.ts
@@ -11,6 +11,7 @@ import {
   findUnclassifiedMethod,
   findAccountByUserId,
   findByPkAndPushUser,
+  findDuplicateCategory,
 } from './static';
 
 export interface IAccount {
@@ -55,6 +56,11 @@ export interface IAccountModel extends Model<IAccountDocument> {
   findUnclassifiedMethod(accountObjId: string): Promise<any>;
   findAccountByUserId(userId: string): Promise<any>;
   findByPkAndPushUser(userObjId: string, accountObjId: string): Promise<any>;
+  findDuplicateCategory(
+    accountObjId: string,
+    type: string,
+    title: string,
+  ): Promise<any>;
 }
 
 export const AccountSchema = new Schema({
@@ -92,6 +98,7 @@ AccountSchema.statics.findAccountByUserId = findAccountByUserId;
 AccountSchema.statics.findByPkAndPushUser = findByPkAndPushUser;
 AccountSchema.statics.findUnclassifiedCategory = findUnclassifiedCategory;
 AccountSchema.statics.findUnclassifiedMethod = findUnclassifiedMethod;
+AccountSchema.statics.findDuplicateCategory = findDuplicateCategory;
 
 export const AccountModel = model<IAccountDocument, IAccountModel>(
   'accounts',

--- a/be/src/models/account/static.ts
+++ b/be/src/models/account/static.ts
@@ -124,3 +124,18 @@ export async function findUnclassifiedCategory(
 
   return res.categories[0]._id;
 }
+
+export async function findDuplicateCategory(
+  this: IAccountModel,
+  accountObjId: string,
+  type: string,
+  title: string,
+) {
+  return AccountModel.findById(accountObjId, {
+    categories: true,
+  }).populate({
+    path: 'categories',
+    match: { type, title },
+    select: '_id',
+  });
+}

--- a/be/src/routers/api/category/index.ts
+++ b/be/src/routers/api/category/index.ts
@@ -1,15 +1,29 @@
 import Router from 'koa-router';
 import koaCompose from 'koa-compose';
 import categoryController from 'controllers/category';
-import { isUnclassifide, titleIsUnclassified } from 'middlewares';
+import {
+  isUnclassifide,
+  titleIsUnclassified,
+  isVaildLengthTitle,
+} from 'middlewares';
 
 const router = new Router();
 
 router.get('/statistics', categoryController.getStatisticsInfo);
 
 router.get('/', categoryController.get);
-router.post('/', koaCompose([titleIsUnclassified, categoryController.post]));
-router.put('/', koaCompose([titleIsUnclassified, categoryController.put]));
+router.post(
+  '/',
+  koaCompose([
+    titleIsUnclassified,
+    isVaildLengthTitle,
+    categoryController.post,
+  ]),
+);
+router.put(
+  '/',
+  koaCompose([titleIsUnclassified, isVaildLengthTitle, categoryController.put]),
+);
 router.delete(
   '/:category',
   koaCompose([isUnclassifide, categoryController.deleteCategory]),

--- a/be/src/routers/api/method/index.ts
+++ b/be/src/routers/api/method/index.ts
@@ -1,16 +1,19 @@
 import Router from 'koa-router';
 import methodController from 'controllers/method';
 import koaCompose from 'koa-compose';
-import { titleIsUnclassified } from 'middlewares';
+import { titleIsUnclassified, isVaildLengthTitle } from 'middlewares';
 
 const router = new Router();
 
 router.get('/', methodController.get);
-router.post('/', koaCompose([titleIsUnclassified, methodController.post]));
+router.post(
+  '/',
+  koaCompose([titleIsUnclassified, isVaildLengthTitle, methodController.post]),
+);
 router.delete('/:methodObjId', methodController.del);
 router.put(
   '/:methodObjId',
-  koaCompose([titleIsUnclassified, methodController.put]),
+  koaCompose([titleIsUnclassified, isVaildLengthTitle, methodController.put]),
 );
 
 export default router;

--- a/be/src/services/category/index.ts
+++ b/be/src/services/category/index.ts
@@ -146,8 +146,8 @@ export const updateCategory = async (
   });
 
   if (
-    String(exist.categories[0]._id) === objId ||
-    exist.categories.length === 0
+    exist.categories.length === 0 ||
+    String(exist.categories[0]._id) === objId
   ) {
     await CategoryModel.update(
       { _id: objId },

--- a/be/src/services/category/index.ts
+++ b/be/src/services/category/index.ts
@@ -2,6 +2,7 @@ import { AccountModel } from 'models/account';
 import { CategoryModel, categoryType } from 'models/category';
 import { TransactionModel } from 'models/transaction';
 import { getCompFuncByKey } from 'libs/utils';
+import { duplicatedValue } from 'libs/error';
 import { ITotalPrice, ICategoryStatistics, IStatistics } from './index.type';
 
 const getSumByCategories = (
@@ -109,25 +110,23 @@ export const postCategory = async (
   color: string,
   accountObjId: string,
 ) => {
-  const res = await CategoryModel.findOne({ title });
-  if (res != null) {
-    return { success: false, error: '중복된 타이틀 존재' };
-  }
+  const exist: any = await AccountModel.findDuplicateCategory(
+    accountObjId,
+    type,
+    title,
+  );
+  if (exist.categories.length !== 0) throw duplicatedValue;
+
   const newCategory = new CategoryModel({
     type,
     title,
     color,
   });
-  try {
-    await newCategory.save();
-    await AccountModel.update(
-      { _id: accountObjId },
-      { $push: { categories: newCategory._id } },
-    );
-    return { success: true, newCategory };
-  } catch (e) {
-    return { success: false, message: e };
-  }
+  const updateAccount = AccountModel.update(
+    { _id: accountObjId },
+    { $push: { categories: newCategory._id } },
+  );
+  return Promise.all([newCategory.save(), updateAccount]);
 };
 
 export const updateCategory = async (
@@ -137,14 +136,11 @@ export const updateCategory = async (
   color: string,
   accountObjId: string,
 ) => {
-  const exist: any = await AccountModel.findById(accountObjId, {
-    categories: true,
-  }).populate({
-    path: 'categories',
-    match: { type, title },
-    select: '_id',
-  });
-
+  const exist: any = await AccountModel.findDuplicateCategory(
+    accountObjId,
+    type,
+    title,
+  );
   if (
     exist.categories.length === 0 ||
     String(exist.categories[0]._id) === objId

--- a/fe/src/components/atoms/DatePicker/index.tsx
+++ b/fe/src/components/atoms/DatePicker/index.tsx
@@ -18,10 +18,6 @@ export interface IDatePicker {
 export interface IButton {
   onClick?: any;
 }
-export interface ICustomInput {
-  value?: any;
-  onClick?: any;
-}
 
 const DatePicker = ({
   date,

--- a/fe/src/components/atoms/DatePicker/style.ts
+++ b/fe/src/components/atoms/DatePicker/style.ts
@@ -20,6 +20,9 @@ export const Container = styled.div`
     border: none;
     outline: none;
   }
+  input {
+    width: 4em;
+  }
 `;
 
 export const DecsContainer = styled.div`

--- a/fe/src/components/molecules/CategoryDropdown/style.ts
+++ b/fe/src/components/molecules/CategoryDropdown/style.ts
@@ -32,6 +32,10 @@ export const DropdownBodyWrap = styled.div`
   .title-container {
     margin-right: auto;
     height: 1.5em;
+    width: 100%;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
   }
   .modify-button {
     margin-right: 0.5em;

--- a/fe/src/components/molecules/DateRange/index.tsx
+++ b/fe/src/components/molecules/DateRange/index.tsx
@@ -16,7 +16,7 @@ const DateRange = ({ dates, onChange, disabled = false }: IDateRange) => {
     <S.DecsContainer>
       <div>
         <S.Small>시작일</S.Small>
-        <div>
+        <div className="date-container">
           <DatePicker
             date={dates.startDate}
             name="startDate"
@@ -27,7 +27,7 @@ const DateRange = ({ dates, onChange, disabled = false }: IDateRange) => {
       </div>
       <div>
         <S.Small>마지막일</S.Small>
-        <div>
+        <div className="date-container">
           <DatePicker
             date={dates.endDate}
             name="endDate"

--- a/fe/src/components/molecules/DateRange/style.ts
+++ b/fe/src/components/molecules/DateRange/style.ts
@@ -8,6 +8,10 @@ export const DecsContainer = styled.div`
   padding: 0.5rem 0.3rem;
   background: transparent;
   background: ${({ theme }) => theme.color.white};
+  .date-container {
+    display: flex;
+    justify-content: center;
+  }
 `;
 export const Small = styled.small`
   font-size: 0.8rem;

--- a/fe/src/components/molecules/DropdownBody/style.ts
+++ b/fe/src/components/molecules/DropdownBody/style.ts
@@ -7,16 +7,11 @@ export const CheckBoxContainer = styled.div`
 export const DropdownBodyWrap = styled.div`
   display: flex;
   flex-direction: column;
-  position: absolute;
   background-color: white;
-  width: inherit;
   max-height: 35vh;
   overflow-y: auto;
-  z-index: 10;
   border: 1px solid ${({ theme }) => theme.color.subText};
   padding: 0.3em;
-  top: 1.3rem;
-  left: 0;
   .dropdown-item + .dropdown-item {
     border-top: 1px solid ${({ theme }) => theme.color.subText};
   }
@@ -25,15 +20,9 @@ export const DropdownBodyWrap = styled.div`
     align-items: center;
     border: none;
     padding: 0.5rem;
+    min-width: 10rem;
     background: transparent;
     display: flex;
     color: ${({ theme }) => theme.color.black};
-  }
-  @media only screen and (max-width: 600px) {
-    position: fixed;
-    top: 50%;
-    left: 50%;
-    max-width: 50vw;
-    transform: translate(-50%, -50%);
   }
 `;

--- a/fe/src/components/molecules/DropdownBody/style.ts
+++ b/fe/src/components/molecules/DropdownBody/style.ts
@@ -10,6 +10,8 @@ export const DropdownBodyWrap = styled.div`
   position: absolute;
   background-color: white;
   width: inherit;
+  max-height: 35vh;
+  overflow-y: auto;
   z-index: 10;
   border: 1px solid ${({ theme }) => theme.color.subText};
   padding: 0.3em;
@@ -26,5 +28,12 @@ export const DropdownBodyWrap = styled.div`
     background: transparent;
     display: flex;
     color: ${({ theme }) => theme.color.black};
+  }
+  @media only screen and (max-width: 600px) {
+    position: fixed;
+    top: 50%;
+    left: 50%;
+    max-width: 50vw;
+    transform: translate(-50%, -50%);
   }
 `;

--- a/fe/src/components/molecules/DropdownHeader/index.tsx
+++ b/fe/src/components/molecules/DropdownHeader/index.tsx
@@ -1,5 +1,6 @@
 import React, { useRef } from 'react';
 import useVisible from 'hooks/useVisible';
+import ModalContainer from '../ModalContainer';
 
 import * as S from './style';
 
@@ -19,13 +20,21 @@ const DropdownButtonHeader = ({
 }: Props) => {
   const dropdownContainer = useRef<HTMLDivElement>(null);
   const [visible, toogleVisivle] = useVisible(dropdownContainer);
-
+  const onClickVisible = (e: MouseEvent) => {
+    e.preventDefault();
+    e.stopPropagation();
+    toogleVisivle();
+  };
   return (
-    <S.Container ref={dropdownContainer} border={border}>
-      <S.DropdownButton onClick={toogleVisivle} disabled={disabled}>
+    <S.Container border={border}>
+      <S.DropdownButton onClick={onClickVisible} disabled={disabled}>
         <div>{`${title} ${arrowCharacter}`}</div>
       </S.DropdownButton>
-      {visible && children}
+      {visible && (
+        <ModalContainer>
+          <div ref={dropdownContainer}>{children}</div>
+        </ModalContainer>
+      )}
     </S.Container>
   );
 };

--- a/fe/src/components/organisms/MainFilterForm/style.ts
+++ b/fe/src/components/organisms/MainFilterForm/style.ts
@@ -3,10 +3,9 @@ import Button from 'components/atoms/Button';
 import Input from 'components/atoms/Input';
 
 export const Container = styled.section`
-  position: absolute;
+  position: relative;
   left: 0;
   top: 1.5rem;
-  z-index: 10;
   min-width: 80vw;
   border: 1px solid ${({ theme }) => theme.color.subText};
   background: ${({ theme }) => theme.color.white};
@@ -61,12 +60,9 @@ export const DateContainer = styled.div`
 `;
 
 export const DateFilterContainer = styled.div`
-  position: absolute;
-  width: calc(100% - 0.6em);
   border: 1px solid ${({ theme }) => theme.color.subText};
   padding: 0.3em;
   background: white;
-  z-index: 10;
 `;
 
 export const DateFilterButton = styled(Button)`
@@ -80,17 +76,4 @@ export const DateFilterButton = styled(Button)`
 export const BottomButton = styled(Input)`
   border: none;
   background: ${({ theme }) => theme.color.brandColor};
-`;
-
-export const Model = styled.div`
-  position: fixed;
-  top: 0;
-  left: 0;
-  z-index: 999;
-  width: 100vw;
-  height: 100vh;
-  display: flex;
-  justify-content: center;
-  align-items: center;
-  background: rgba(0, 0, 0, 0.5);
 `;

--- a/fe/src/components/organisms/TransactionInputField/index.tsx
+++ b/fe/src/components/organisms/TransactionInputField/index.tsx
@@ -44,7 +44,7 @@ const TransactionInputField = ({
   const categories = CategoryStore.getCategories(classification);
 
   return (
-    <>
+    <S.Container>
       <LabelWrap htmlFor={PRICE} title="금액">
         <S.Input
           value={price}
@@ -115,7 +115,7 @@ const TransactionInputField = ({
           onChangeHandler={formHandler}
         />
       </LabelWrap>
-    </>
+    </S.Container>
   );
 };
 

--- a/fe/src/components/organisms/TransactionInputField/index.tsx
+++ b/fe/src/components/organisms/TransactionInputField/index.tsx
@@ -1,18 +1,13 @@
+/* eslint-disable react/jsx-curly-newline */
 import React from 'react';
 import LabelWrap from 'components/molecules/LabelWrap';
-import ReactDatePicker, {
-  registerLocale,
-  setDefaultLocale,
-} from 'react-datepicker';
 import 'react-datepicker/dist/react-datepicker.css';
-import ko from 'date-fns/locale/ko';
 import { MethodStore } from 'stores/Method';
 import { CategoryStore } from 'stores/Category';
 import { observer } from 'mobx-react-lite';
+import DatePicker from 'components/atoms/DatePicker';
 import * as S from './style';
 
-registerLocale('ko', ko);
-setDefaultLocale('ko');
 const CLASSIFICATION = 'classification';
 const CATEGORY = 'category';
 const MEMO = 'memo';
@@ -97,14 +92,13 @@ const TransactionInputField = ({
         </select>
       </LabelWrap>
       <LabelWrap htmlFor={DATE} title="날짜">
-        <ReactDatePicker
-          selected={new Date(date)}
-          onChange={(d) => formHandler({ target: { name: DATE, value: d } })}
-          className="my-react-picker"
-          locale={ko}
-          dateFormat="yyyy-MM-dd"
-          popperPlacement="auto"
-          popperModifiers={{ preventOverflow: { enabled: true } }}
+        <DatePicker
+          date={new Date(date)}
+          name={DATE}
+          disabled={false}
+          onChange={(d: Date) =>
+            formHandler({ target: { name: DATE, value: d } })
+          }
         />
       </LabelWrap>
       <LabelWrap htmlFor={MEMO} title="메모">

--- a/fe/src/components/organisms/TransactionInputField/style.ts
+++ b/fe/src/components/organisms/TransactionInputField/style.ts
@@ -27,3 +27,12 @@ export const Form = styled.form`
     margin-top: 1rem;
   }
 `;
+
+export const Container = styled.div`
+  padding: 1rem 1rem;
+  select {
+    width: 100%;
+    border: 0;
+    border-bottom: 1px solid ${({ theme }) => theme.color.subText};
+  }
+`;

--- a/fe/src/components/templates/FormTransaction/style.ts
+++ b/fe/src/components/templates/FormTransaction/style.ts
@@ -8,5 +8,8 @@ export const Header = styled.header`
 `;
 
 export const Main = styled.main`
-  margin: 10% 0;
+  margin-top: 3rem;
+  height: calc(100vh - 8rem);
+  overflow-x: hidden;
+  overflow-y: auto;
 `;

--- a/fe/src/components/templates/MainTemplate/style.ts
+++ b/fe/src/components/templates/MainTemplate/style.ts
@@ -12,7 +12,6 @@ export const ContentArea = styled.div`
   overflow-y: auto;
   box-sizing: border-box;
   position: absolute;
-  z-index: -1;
   width: 100%;
   top: 3rem;
   height: calc(100vh - 3rem - 4rem - 2px);
@@ -22,7 +21,6 @@ export const ContentArea = styled.div`
 
 export const Header = styled.header`
   position: absolute;
-  z-index: 10;
   top: 0;
   left: 0;
   width: 100%;

--- a/fe/src/pages/CategoryPage/index.tsx
+++ b/fe/src/pages/CategoryPage/index.tsx
@@ -92,8 +92,15 @@ function CategoryPage(): React.ReactElement {
     loadStore();
     setDeleteVisible(false);
   };
-
+  const isVaildLengthTitle = (title: string) => {
+    return title && title.length >= 1 && title.length <= 20;
+  };
   const confirm = async () => {
+    const trimedTitle = inputRef.current.value.trim();
+    if (!isVaildLengthTitle(trimedTitle)) {
+      alert('최대 20자까지 입력이 가능합니다.');
+      return;
+    }
     const apiFuc = type === 'METHOD' ? methodConfirm : categoryConfirm;
     const result: any = await apiFuc();
     if (result.error) {
@@ -105,6 +112,15 @@ function CategoryPage(): React.ReactElement {
     }
   };
   const methodConfirm = async () => {
+    const exist = MethodStore.getMethods().find(
+      (method) => method.title === inputRef.current.value.trim(),
+    );
+    if (exist && exist._id === selectedRef.current) {
+      return Promise.resolve({ error: '변경사항이 없습니다!' });
+    }
+    if (exist) {
+      return Promise.resolve({ error: '중복되는 입력입니다!' });
+    }
     const body = {
       title: inputRef.current.value,
     };
@@ -114,6 +130,15 @@ function CategoryPage(): React.ReactElement {
     return func(TransactionStore.accountObjId, body, selectedRef.current);
   };
   const categoryConfirm = async () => {
+    const exist = CategoryStore.getCategories(type).find(
+      (category) => category.title === inputRef.current.value.trim(),
+    );
+    if (exist && exist._id === selectedRef.current) {
+      return Promise.resolve({ error: '변경사항이 없습니다!' });
+    }
+    if (exist) {
+      return Promise.resolve({ error: '중복되는 입력입니다!' });
+    }
     const body = {
       type,
       title: inputRef.current.value,
@@ -128,10 +153,12 @@ function CategoryPage(): React.ReactElement {
 
   const onCancle = (fnc: any) => () => {
     inputRef.current.value = '';
+    selectedRef.current = '';
     fnc(false);
   };
 
   const onPlusButtonClick = () => {
+    inputRef.current.value = '';
     colorPicker.current.value = getRandomColor();
     setVisible(true);
   };


### PR DESCRIPTION
## 변경사항
<p>
<img src='https://user-images.githubusercontent.com/44409642/102112374-f3ac0000-3e7a-11eb-9e3a-cb6bd4e493ff.png' width= '35%'/>
<img src='https://user-images.githubusercontent.com/44409642/102112388-f73f8700-3e7a-11eb-9377-b62dbc79ab07.png' width= '35%'/>
</p>

select 에 css 를 주었습니다. 내부 항목이 길어지면 같이 길어지는 경향이 있어 길이도 지정 하였습니다. 

date picker 같은 경우 필터에서 사용된 컴포넌트를 그대로 사용 하였습니다. 

## 멘토님들

@boostcamp-2020/accountbook_mentor

