### PR TITLE
브라우저 재시작 시 가계부 리스트 페이지 렌더링 되지 않는 버그 수정

### DIFF
--- a/fe/src/apis/user.ts
+++ b/fe/src/apis/user.ts
@@ -13,6 +13,9 @@ export default {
   getUserInvitation(): Promise<IInvitaion[]> {
     return axios.get(urls.getUserInvitation());
   },
+  getUserInfo(): Promise<IUser> {
+    return axios.get(`${urls.userInfo}`);
+  },
   agreeInvitation(accountObjId: string) {
     return axios.post(urls.postAndDeleteInvitation(accountObjId));
   },

--- a/fe/src/pages/AccountListPage/index.tsx
+++ b/fe/src/pages/AccountListPage/index.tsx
@@ -7,8 +7,8 @@ import { AccountStore } from 'stores/Account';
 import Account from 'components/organisms/Account';
 import { useHistory } from 'react-router-dom';
 import AccountSvg from 'assets/svg/account.svg';
-import axios from 'apis/axios';
-import url from 'apis/urls';
+import userApi from 'apis/user';
+
 import * as S from './styles';
 
 const onClickHandler = (
@@ -64,7 +64,7 @@ const AccountListPage = () => {
 
   if (!userId && loading === false) {
     setLoading(true);
-    axios.get(`${url.userInfo}`).then((res) => {
+    userApi.getUserInfo().then((res) => {
       sessionStorage.setItem('userObjId', (res as any)._id);
       sessionStorage.setItem(
         'userIsSundayStart',

--- a/fe/src/pages/AccountListPage/index.tsx
+++ b/fe/src/pages/AccountListPage/index.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect } from 'react';
+import React, { useEffect, useState } from 'react';
 import { observer } from 'mobx-react-lite';
 import { TransactionStore } from 'stores/Transaction';
 import Template from 'components/templates/MainTemplate';
@@ -7,6 +7,8 @@ import { AccountStore } from 'stores/Account';
 import Account from 'components/organisms/Account';
 import { useHistory } from 'react-router-dom';
 import AccountSvg from 'assets/svg/account.svg';
+import axios from 'apis/axios';
+import url from 'apis/urls';
 import * as S from './styles';
 
 const onClickHandler = (
@@ -51,11 +53,26 @@ const newAccountClickHandler = (history: any, userId: String) => () => {
 
 const AccountListPage = () => {
   const history = useHistory();
-
+  const [loading, setLoading] = useState<boolean>(false);
   const userId = sessionStorage.getItem('userObjId');
-  if (!userId) {
-    window.location.href = '/accounts';
-    return <></>;
+
+  useEffect(() => {
+    if (!loading) {
+      AccountStore.loadAccounts();
+    }
+  }, [loading]);
+
+  if (!userId && loading === false) {
+    setLoading(true);
+    axios.get(`${url.userInfo}`).then((res) => {
+      sessionStorage.setItem('userObjId', (res as any)._id);
+      sessionStorage.setItem(
+        'userIsSundayStart',
+        String((res as any).startOfWeek === 'sunday'),
+      );
+      setLoading(false);
+    });
+    return <>로딩중</>;
   }
 
   const List = AccountStore.getAccountList().map((el) => {
@@ -76,9 +93,6 @@ const AccountListPage = () => {
     </S.SubmitButton>
   );
 
-  useEffect(() => {
-    AccountStore.loadAccounts();
-  }, []);
   return (
     <Template
       HeaderBar={<Header />}

--- a/fe/src/pages/AccountListPage/index.tsx
+++ b/fe/src/pages/AccountListPage/index.tsx
@@ -54,6 +54,7 @@ const AccountListPage = () => {
 
   const userId = sessionStorage.getItem('userObjId');
   if (!userId) {
+    window.location.href = '/accounts';
     return <></>;
   }
 

--- a/fe/src/pages/AuthCheck/index.tsx
+++ b/fe/src/pages/AuthCheck/index.tsx
@@ -1,10 +1,9 @@
 import React from 'react';
-import axios from 'apis/axios';
-import url from 'apis/urls';
+import userApi from 'apis/user';
 
 const AuthCheck = () => {
   if (!sessionStorage.getItem('userObjId')) {
-    axios.get(`${url.userInfo}`).then((res) => {
+    userApi.getUserInfo().then((res) => {
       sessionStorage.setItem('userObjId', (res as any)._id);
       sessionStorage.setItem(
         'userIsSundayStart',

--- a/fe/src/pages/AuthCheck/index.tsx
+++ b/fe/src/pages/AuthCheck/index.tsx
@@ -1,9 +1,8 @@
-import React, { useEffect } from 'react';
+import React from 'react';
 import axios from 'apis/axios';
 import url from 'apis/urls';
 
 const AuthCheck = () => {
-  useEffect(() => {});
   if (!sessionStorage.getItem('userObjId')) {
     axios.get(`${url.userInfo}`).then((res) => {
       sessionStorage.setItem('userObjId', (res as any)._id);


### PR DESCRIPTION
## 변경사항
### 브라우저 재시작 시 가계부 리스트 렌더링 안되는 것 수정

브라우저를 재시작 시 가계부 리스트 페이지가 렌더링 되지 않던 것 수정했습니다.
sessionstorage에 있던 useObjId가 없을 때 <></>를 렌더링 하게 임시로 구현했었던 것을, 
없으면 user정보를 받아오는 api를 다시 불러오도록 수정했습니다.

### 가계부 리스트 로딩중이라는 글씨 추가
가계부 리스트가 불러오는 중에는 로딩중이라는 글씨가 나오게 했습니다.

## 체크리스트
- [x] 브라우저 재시작시 새로고침 전 아무것도 뜨지 않는 것 수정

## Linked Issues
closes #236 

## 멘토님들

@boostcamp-2020/accountbook_mentor
