### PR TITLE
MonthHeader 컴포넌트 CSS 수정, 404페이지 수정

### DIFF
--- a/fe/src/apis/user.ts
+++ b/fe/src/apis/user.ts
@@ -13,6 +13,9 @@ export default {
   getUserInvitation(): Promise<IInvitaion[]> {
     return axios.get(urls.getUserInvitation());
   },
+  getUserInfo(): Promise<IUser> {
+    return axios.get(`${urls.userInfo}`);
+  },
   agreeInvitation(accountObjId: string) {
     return axios.post(urls.postAndDeleteInvitation(accountObjId));
   },

--- a/fe/src/components/molecules/DateRange/style.ts
+++ b/fe/src/components/molecules/DateRange/style.ts
@@ -12,8 +12,19 @@ export const DecsContainer = styled.div`
     display: flex;
     justify-content: center;
   }
+  .my-react-picker {
+    text-align: center;
+  }
+
+  & > div {
+    padding-top: 0.5rem;
+    display: flex;
+    flex-direction: column;
+    justify-content: center;
+  }
 `;
 export const Small = styled.small`
   font-size: 0.8rem;
+  text-align: center;
   color: ${({ theme }) => theme.color.subText};
 `;

--- a/fe/src/components/organisms/MonthInfoHeader/index.tsx
+++ b/fe/src/components/organisms/MonthInfoHeader/index.tsx
@@ -5,7 +5,7 @@ import { observer } from 'mobx-react-lite';
 import { TransactionStore } from 'stores/Transaction';
 import dateUtils from 'utils/date';
 import DateRange from 'components/molecules/DateRange';
-import { MonthInfoHeaderContainer, MonthButton } from './style';
+import * as S from './style';
 
 interface MonthInfoHeaderInterface {
   date?: any;
@@ -32,18 +32,16 @@ const MonthInfoHeader = ({
   const { title, owner } = useParams<Params>();
   const baseUrl = `/transactions/${owner}/${title}`;
   return (
-    <MonthInfoHeaderContainer>
+    <S.MonthInfoHeaderContainer>
       <DateRange dates={date} disabled />
       <div>
         <TotalBox title="수입" total={total.income} />
         <TotalBox title="지출" total={total.expense} />
       </div>
       <Link to={`${baseUrl}/chatting`}>
-        <MonthButton onClick={() => {}} size="md">
-          채팅
-        </MonthButton>
+        <S.MonthButton onClick={() => {}}>채팅</S.MonthButton>
       </Link>
-    </MonthInfoHeaderContainer>
+    </S.MonthInfoHeaderContainer>
   );
 };
 

--- a/fe/src/components/organisms/MonthInfoHeader/style.ts
+++ b/fe/src/components/organisms/MonthInfoHeader/style.ts
@@ -15,6 +15,10 @@ export const MonthButton = styled(Button)<MonthHeaderInfoButton>`
   height: 2.5rem;
   border-radius: 1.25rem;
   border: 1px solid ${({ theme }) => theme.color.brandColor};
+  :hover {
+    color: ${({ theme }) => theme.color.white};
+    background-color: ${({ theme }) => theme.color.brandColor};
+  }
   ${({ border, theme }) =>
     border &&
     css`

--- a/fe/src/components/organisms/MonthInfoHeader/style.ts
+++ b/fe/src/components/organisms/MonthInfoHeader/style.ts
@@ -11,8 +11,10 @@ export const MonthButton = styled(Button)<MonthHeaderInfoButton>`
   color: ${({ color, theme }) =>
     color ? theme.color[color] : theme.color.brandColor};
   border: 0;
-  width: 100%;
-  height: 50%;
+  width: 2.5rem;
+  height: 2.5rem;
+  border-radius: 1.25rem;
+  border: 1px solid ${({ theme }) => theme.color.brandColor};
   ${({ border, theme }) =>
     border &&
     css`

--- a/fe/src/pages/404Page/index.tsx
+++ b/fe/src/pages/404Page/index.tsx
@@ -1,7 +1,0 @@
-import React from 'react';
-
-const Page404 = () => {
-  return <div>404page~</div>;
-};
-
-export default Page404;

--- a/fe/src/pages/AccountListPage/index.tsx
+++ b/fe/src/pages/AccountListPage/index.tsx
@@ -7,8 +7,8 @@ import { AccountStore } from 'stores/Account';
 import Account from 'components/organisms/Account';
 import { useHistory } from 'react-router-dom';
 import AccountSvg from 'assets/svg/account.svg';
-import axios from 'apis/axios';
-import url from 'apis/urls';
+import userApi from 'apis/user';
+
 import * as S from './styles';
 
 const onClickHandler = (
@@ -64,7 +64,7 @@ const AccountListPage = () => {
 
   if (!userId && loading === false) {
     setLoading(true);
-    axios.get(`${url.userInfo}`).then((res) => {
+    userApi.getUserInfo().then((res) => {
       sessionStorage.setItem('userObjId', (res as any)._id);
       sessionStorage.setItem(
         'userIsSundayStart',

--- a/fe/src/pages/AccountListPage/index.tsx
+++ b/fe/src/pages/AccountListPage/index.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect } from 'react';
+import React, { useEffect, useState } from 'react';
 import { observer } from 'mobx-react-lite';
 import { TransactionStore } from 'stores/Transaction';
 import Template from 'components/templates/MainTemplate';
@@ -7,6 +7,8 @@ import { AccountStore } from 'stores/Account';
 import Account from 'components/organisms/Account';
 import { useHistory } from 'react-router-dom';
 import AccountSvg from 'assets/svg/account.svg';
+import axios from 'apis/axios';
+import url from 'apis/urls';
 import * as S from './styles';
 
 const onClickHandler = (
@@ -51,11 +53,26 @@ const newAccountClickHandler = (history: any, userId: String) => () => {
 
 const AccountListPage = () => {
   const history = useHistory();
-
+  const [loading, setLoading] = useState<boolean>(false);
   const userId = sessionStorage.getItem('userObjId');
-  if (!userId) {
-    window.location.href = '/accounts';
-    return <></>;
+
+  useEffect(() => {
+    if (!loading) {
+      AccountStore.loadAccounts();
+    }
+  }, [loading]);
+
+  if (!userId && loading === false) {
+    setLoading(true);
+    axios.get(`${url.userInfo}`).then((res) => {
+      sessionStorage.setItem('userObjId', (res as any)._id);
+      sessionStorage.setItem(
+        'userIsSundayStart',
+        String((res as any).startOfWeek === 'sunday'),
+      );
+      setLoading(false);
+    });
+    return <>로딩중</>;
   }
 
   const List = AccountStore.getAccountList().map((el) => {
@@ -76,9 +93,6 @@ const AccountListPage = () => {
     </S.SubmitButton>
   );
 
-  useEffect(() => {
-    AccountStore.loadAccounts();
-  }, []);
   return (
     <Template
       HeaderBar={<Header />}

--- a/fe/src/pages/AccountListPage/index.tsx
+++ b/fe/src/pages/AccountListPage/index.tsx
@@ -54,6 +54,7 @@ const AccountListPage = () => {
 
   const userId = sessionStorage.getItem('userObjId');
   if (!userId) {
+    window.location.href = '/accounts';
     return <></>;
   }
 

--- a/fe/src/pages/AuthCheck/index.tsx
+++ b/fe/src/pages/AuthCheck/index.tsx
@@ -1,10 +1,9 @@
 import React from 'react';
-import axios from 'apis/axios';
-import url from 'apis/urls';
+import userApi from 'apis/user';
 
 const AuthCheck = () => {
   if (!sessionStorage.getItem('userObjId')) {
-    axios.get(`${url.userInfo}`).then((res) => {
+    userApi.getUserInfo().then((res) => {
       sessionStorage.setItem('userObjId', (res as any)._id);
       sessionStorage.setItem(
         'userIsSundayStart',

--- a/fe/src/pages/AuthCheck/index.tsx
+++ b/fe/src/pages/AuthCheck/index.tsx
@@ -1,9 +1,8 @@
-import React, { useEffect } from 'react';
+import React from 'react';
 import axios from 'apis/axios';
 import url from 'apis/urls';
 
 const AuthCheck = () => {
-  useEffect(() => {});
   if (!sessionStorage.getItem('userObjId')) {
     axios.get(`${url.userInfo}`).then((res) => {
       sessionStorage.setItem('userObjId', (res as any)._id);

--- a/fe/src/pages/NotFoundPage/index.tsx
+++ b/fe/src/pages/NotFoundPage/index.tsx
@@ -1,7 +1,18 @@
 import React from 'react';
+import * as S from './style';
 
 const NotFoundPage = () => {
-  return <div>404page~</div>;
+  return (
+    <S.NotFound>
+      <img
+        src="https://camo.githubusercontent.com/9acad1537ebb0c3e10abbf4b74ef2d1929c2d504a91e8cd49bfcd1ddbeff4f9d/68747470733a2f2f692e696d6775722e636f6d2f633238335a764a2e706e67"
+        width="300px"
+        alt="404"
+      />
+      <div className="big">404</div>
+      <div className="small">페이지를 찾을 수 없습니다.</div>
+    </S.NotFound>
+  );
 };
 
 export default NotFoundPage;

--- a/fe/src/pages/NotFoundPage/style.ts
+++ b/fe/src/pages/NotFoundPage/style.ts
@@ -1,0 +1,23 @@
+import styled from 'styled-components';
+
+export const NotFound = styled.div`
+  position: fixed;
+  width: 100%;
+  height: 100%;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+  div {
+    padding-top: 0.5em;
+  }
+  .big {
+    font-size: 2rem;
+  }
+  .small {
+    font-size: 1.5rem;
+    color: ${({ theme }) => theme.color.subText};
+  }
+`;
+
+export default NotFound;


### PR DESCRIPTION
## 변경사항
### MonthHeader 컴포넌트 CSS
![image](https://user-images.githubusercontent.com/34783156/102226245-84daaf80-3f2b-11eb-8530-944ae6a69dc2.png)
텍스트 중앙정렬하고 채팅버튼 크기와 hover 관련 옵션 추가했습니다.

### 404페이지
![image](https://user-images.githubusercontent.com/34783156/102226188-72f90c80-3f2b-11eb-9148-104bd288c030.png)
404페이지를 수정했습니다.

## Linked Issues
closes #239

## 멘토님들

@boostcamp-2020/accountbook_mentor
