### PR TITLE
가계부 생성시 바로 등록되는 버그 수정

### DIFF
--- a/be/src/controllers/account/index.ts
+++ b/be/src/controllers/account/index.ts
@@ -16,7 +16,7 @@ export const get = async (ctx: Koa.Context) => {
 
 export const postAccount = async (ctx: Koa.Context) => {
   const { user, title, userObjIdList } = ctx.request.body;
-  await accountService.CreateNewAccount(user, title, userObjIdList);
+  await accountService.createNewAccount(user, title, userObjIdList);
   ctx.status = 201;
   ctx.response.body = { success: true };
 };

--- a/be/src/controllers/account/index.ts
+++ b/be/src/controllers/account/index.ts
@@ -18,7 +18,6 @@ export const postAccount = async (ctx: Koa.Context) => {
   await accountService.addAccountByUserAndAccountInfo(
     ctx.request.body.user,
     ctx.request.body.title,
-    ctx.request.body.userObjIdList,
   );
   ctx.status = 201;
   ctx.response.body = { success: true };

--- a/be/src/controllers/account/index.ts
+++ b/be/src/controllers/account/index.ts
@@ -15,10 +15,8 @@ export const get = async (ctx: Koa.Context) => {
 };
 
 export const postAccount = async (ctx: Koa.Context) => {
-  await accountService.addAccountByUserAndAccountInfo(
-    ctx.request.body.user,
-    ctx.request.body.title,
-  );
+  const { user, title, userObjIdList } = ctx.request.body;
+  await accountService.CreateNewAccount(user, title, userObjIdList);
   ctx.status = 201;
   ctx.response.body = { success: true };
 };

--- a/be/src/services/account/index.ts
+++ b/be/src/services/account/index.ts
@@ -26,7 +26,6 @@ export const getAccountByTitleAndOwner = async (
 export const addAccountByUserAndAccountInfo = async (
   user: IUserDocument,
   title: any,
-  userObjIdList: String[],
 ) => {
   const [categories, methods] = await Promise.all([
     CategoryModel.createDefaultCategory(),
@@ -41,19 +40,7 @@ export const addAccountByUserAndAccountInfo = async (
     users: [user],
     imageUrl: user.profileUrl,
   });
-  return Promise.all([
-    newAccount.save(),
-    UserModel.updateMany(
-      {
-        _id: { $in: userObjIdList },
-      },
-      {
-        $addToSet: {
-          invitations: { host: user.nickname, accounts: newAccount._id },
-        },
-      },
-    ),
-  ]);
+  return newAccount.save();
 };
 
 export const updateAccountByUserAndAccountInfo = async (

--- a/be/src/services/account/index.ts
+++ b/be/src/services/account/index.ts
@@ -23,9 +23,10 @@ export const getAccountByTitleAndOwner = async (
   return account;
 };
 
-export const addAccountByUserAndAccountInfo = async (
+export const CreateNewAccount = async (
   user: IUserDocument,
   title: any,
+  userObjIdList: string[],
 ) => {
   const [categories, methods] = await Promise.all([
     CategoryModel.createDefaultCategory(),
@@ -40,7 +41,20 @@ export const addAccountByUserAndAccountInfo = async (
     users: [user],
     imageUrl: user.profileUrl,
   });
-  return newAccount.save();
+  const inviteUsers = UserModel.updateMany(
+    {
+      _id: { $in: userObjIdList },
+    },
+    {
+      $addToSet: {
+        invitations: {
+          host: user.nickname,
+          accounts: newAccount._id,
+        },
+      },
+    },
+  );
+  return Promise.all([newAccount.save(), inviteUsers]);
 };
 
 export const updateAccountByUserAndAccountInfo = async (

--- a/be/src/services/account/index.ts
+++ b/be/src/services/account/index.ts
@@ -23,7 +23,7 @@ export const getAccountByTitleAndOwner = async (
   return account;
 };
 
-export const CreateNewAccount = async (
+export const createNewAccount = async (
   user: IUserDocument,
   title: any,
   userObjIdList: string[],


### PR DESCRIPTION
## 변경사항
기존에 가계부 생성하면 바로 accounts에 users에 들어가도록 구현된 것을 
초대된 사용자 아이디의 invitations 에 생성된 accountObjId를 넣었습니다.

## Linked Issues
closes #240 

## 멘토님들

@boostcamp-2020/accountbook_mentor
