### PR TITLE
가계부 수정 시 사용자 목록 초가 되는 버그 수정

### DIFF
--- a/be/src/controllers/account/index.ts
+++ b/be/src/controllers/account/index.ts
@@ -22,10 +22,12 @@ export const postAccount = async (ctx: Koa.Context) => {
 };
 
 export const putAccount = async (ctx: Koa.Context) => {
+  const { user, title, userObjIdList } = ctx.request.body;
   await accountService.updateAccountByUserAndAccountInfo(
-    ctx.request.body.title,
+    title,
     ctx.params.accountObjId,
-    ctx.request.body.userObjIdList,
+    userObjIdList,
+    user,
   );
   ctx.status = 200;
   ctx.response.body = { success: true };


### PR DESCRIPTION
## 변경사항

기존에는 수정했을 때 바로 초대 목록을 users에 덮어썼다. 
- 그래서 기존에 등록된 사용자가 제거 되는 현상 발생
-  바로 등록이 아닌 초대 리스트로 넣어함. 
위에 두 문제를 해결하였습니다.

## Linked Issues
closes #243
 
## 멘토님들

@boostcamp-2020/accountbook_mentor
