### PR TITLE
메인페이지 미분류 합계에서 제외 및  수입 지출 분리하고 색상구별

### DIFF
--- a/be/src/controllers/account/index.ts
+++ b/be/src/controllers/account/index.ts
@@ -18,7 +18,6 @@ export const postAccount = async (ctx: Koa.Context) => {
   await accountService.addAccountByUserAndAccountInfo(
     ctx.request.body.user,
     ctx.request.body.title,
-    ctx.request.body.userObjIdList,
   );
   ctx.status = 201;
   ctx.response.body = { success: true };

--- a/be/src/controllers/account/index.ts
+++ b/be/src/controllers/account/index.ts
@@ -15,10 +15,8 @@ export const get = async (ctx: Koa.Context) => {
 };
 
 export const postAccount = async (ctx: Koa.Context) => {
-  await accountService.addAccountByUserAndAccountInfo(
-    ctx.request.body.user,
-    ctx.request.body.title,
-  );
+  const { user, title, userObjIdList } = ctx.request.body;
+  await accountService.CreateNewAccount(user, title, userObjIdList);
   ctx.status = 201;
   ctx.response.body = { success: true };
 };

--- a/be/src/controllers/account/index.ts
+++ b/be/src/controllers/account/index.ts
@@ -22,10 +22,12 @@ export const postAccount = async (ctx: Koa.Context) => {
 };
 
 export const putAccount = async (ctx: Koa.Context) => {
+  const { user, title, userObjIdList } = ctx.request.body;
   await accountService.updateAccountByUserAndAccountInfo(
-    ctx.request.body.title,
+    title,
     ctx.params.accountObjId,
-    ctx.request.body.userObjIdList,
+    userObjIdList,
+    user,
   );
   ctx.status = 200;
   ctx.response.body = { success: true };

--- a/be/src/services/account/index.ts
+++ b/be/src/services/account/index.ts
@@ -26,7 +26,6 @@ export const getAccountByTitleAndOwner = async (
 export const addAccountByUserAndAccountInfo = async (
   user: IUserDocument,
   title: any,
-  userObjIdList: String[],
 ) => {
   const [categories, methods] = await Promise.all([
     CategoryModel.createDefaultCategory(),
@@ -41,19 +40,7 @@ export const addAccountByUserAndAccountInfo = async (
     users: [user],
     imageUrl: user.profileUrl,
   });
-  return Promise.all([
-    newAccount.save(),
-    UserModel.updateMany(
-      {
-        _id: { $in: userObjIdList },
-      },
-      {
-        $addToSet: {
-          invitations: { host: user.nickname, accounts: newAccount._id },
-        },
-      },
-    ),
-  ]);
+  return newAccount.save();
 };
 
 export const updateAccountByUserAndAccountInfo = async (

--- a/be/src/services/account/index.ts
+++ b/be/src/services/account/index.ts
@@ -23,9 +23,10 @@ export const getAccountByTitleAndOwner = async (
   return account;
 };
 
-export const addAccountByUserAndAccountInfo = async (
+export const CreateNewAccount = async (
   user: IUserDocument,
   title: any,
+  userObjIdList: string[],
 ) => {
   const [categories, methods] = await Promise.all([
     CategoryModel.createDefaultCategory(),
@@ -40,7 +41,20 @@ export const addAccountByUserAndAccountInfo = async (
     users: [user],
     imageUrl: user.profileUrl,
   });
-  return newAccount.save();
+  const inviteUsers = UserModel.updateMany(
+    {
+      _id: { $in: userObjIdList },
+    },
+    {
+      $addToSet: {
+        invitations: {
+          host: user.nickname,
+          accounts: newAccount._id,
+        },
+      },
+    },
+  );
+  return Promise.all([newAccount.save(), inviteUsers]);
 };
 
 export const updateAccountByUserAndAccountInfo = async (

--- a/fe/src/components/atoms/Input/index.tsx
+++ b/fe/src/components/atoms/Input/index.tsx
@@ -26,8 +26,6 @@ const Input = ({
   inputRef,
   ...props
 }: Props): React.ReactElement => {
-  console.log({ ...props });
-
   return (
     <SInput
       id={id}

--- a/fe/src/components/atoms/PriceTag/index.tsx
+++ b/fe/src/components/atoms/PriceTag/index.tsx
@@ -17,7 +17,7 @@ const PriceTag: React.FC<Props> = ({
 }): React.ReactElement => {
   return (
     <PriceContainer bold={bold} size={size} color={color} {...props}>
-      {`${value.toLocaleString()}원`}
+      {value === 0 ? '' : `${value.toLocaleString()}원`}
     </PriceContainer>
   );
 };

--- a/fe/src/components/atoms/PriceTag/index.tsx
+++ b/fe/src/components/atoms/PriceTag/index.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import PriceContainer from './style';
 
-interface Props {
+export interface Props {
   value: number;
   bold?: boolean;
   size?: string;

--- a/fe/src/components/molecules/DateMoneyHeader/index.stories.tsx
+++ b/fe/src/components/molecules/DateMoneyHeader/index.stories.tsx
@@ -11,10 +11,18 @@ export default {
 export const DateMoneyHeaderSample = () => {
   const date = new Date();
   const value = 1000000;
-
+  const income = 400000;
+  const expense = 560000;
+  const unclassified = 0;
   return (
     <ThemeProvider theme={theme}>
-      <DateMoneyHeader totalPayment={value} date={date} />
+      <DateMoneyHeader
+        totalPayment={value}
+        date={date}
+        income={income}
+        expense={expense}
+        unclassified={unclassified}
+      />
     </ThemeProvider>
   );
 };

--- a/fe/src/components/molecules/DateMoneyHeader/index.tsx
+++ b/fe/src/components/molecules/DateMoneyHeader/index.tsx
@@ -21,7 +21,16 @@ const DateMoneyHeader = ({
   return (
     <DateMoneyHeaderStyle {...props}>
       <ReducedDate date={date} parseString="ymdz" />
-      <PriceTag value={totalPayment} bold />
+      <div className="price-container">
+        <div className="price-container__price price-container__price--income">
+          {income === 0 ? '' : `+`}
+          <PriceTag value={income} bold color="selectedBlue" />
+        </div>
+        <div className="price-container__price price-container__price--expense">
+          {expense === 0 ? '' : '-'}
+          <PriceTag value={expense} bold color="red" />
+        </div>
+      </div>
     </DateMoneyHeaderStyle>
   );
 };

--- a/fe/src/components/molecules/DateMoneyHeader/index.tsx
+++ b/fe/src/components/molecules/DateMoneyHeader/index.tsx
@@ -5,9 +5,19 @@ import { DateMoneyHeaderStyle, ReducedDate } from './style';
 export interface Props {
   date: Date;
   totalPayment: number;
+  unclassified: number;
+  income: number;
+  expense: number;
 }
 
-const DateMoneyHeader = ({ date, totalPayment, ...props }: Props) => {
+const DateMoneyHeader = ({
+  date,
+  totalPayment,
+  unclassified,
+  income,
+  expense,
+  ...props
+}: Props) => {
   return (
     <DateMoneyHeaderStyle {...props}>
       <ReducedDate date={date} parseString="ymdz" />

--- a/fe/src/components/molecules/DateMoneyHeader/index.tsx
+++ b/fe/src/components/molecules/DateMoneyHeader/index.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
-import PriceTag from 'components/atoms/PriceTag';
+import PriceWithSign from 'components/molecules/PriceWithSign';
+import { categoryType } from 'stores/Category';
 import { DateMoneyHeaderStyle, ReducedDate } from './style';
 
 export interface Props {
@@ -22,14 +23,8 @@ const DateMoneyHeader = ({
     <DateMoneyHeaderStyle {...props}>
       <ReducedDate date={date} parseString="ymdz" />
       <div className="price-container">
-        <div className="price-container__price price-container__price--income">
-          {income === 0 ? '' : `+`}
-          <PriceTag value={income} bold color="selectedBlue" />
-        </div>
-        <div className="price-container__price price-container__price--expense">
-          {expense === 0 ? '' : '-'}
-          <PriceTag value={expense} bold color="red" />
-        </div>
+        <PriceWithSign price={income} type={categoryType.INCOME} bold />
+        <PriceWithSign price={expense} type={categoryType.EXPENSE} bold />
       </div>
     </DateMoneyHeaderStyle>
   );

--- a/fe/src/components/molecules/DateMoneyHeader/style.ts
+++ b/fe/src/components/molecules/DateMoneyHeader/style.ts
@@ -19,18 +19,5 @@ export const DateMoneyHeaderStyle = styled.div`
   .price-container {
     display: flex;
     align-items: center;
-    &__price {
-      display: flex;
-      align-items: center;
-      &--income {
-        color: ${({ theme }) => theme.color.selectedBlue};
-      }
-      &--expense {
-        color: ${({ theme }) => theme.color.red};
-      }
-    }
-  }
-  .price-container__price + .price-container__price {
-    margin-left: 0.5em;
   }
 `;

--- a/fe/src/components/molecules/DateMoneyHeader/style.ts
+++ b/fe/src/components/molecules/DateMoneyHeader/style.ts
@@ -16,4 +16,21 @@ export const ReducedDate = styled(DateAtom)`
 export const DateMoneyHeaderStyle = styled.div`
   display: flex;
   justify-content: space-between;
+  .price-container {
+    display: flex;
+    align-items: center;
+    &__price {
+      display: flex;
+      align-items: center;
+      &--income {
+        color: ${({ theme }) => theme.color.selectedBlue};
+      }
+      &--expense {
+        color: ${({ theme }) => theme.color.red};
+      }
+    }
+  }
+  .price-container__price + .price-container__price {
+    margin-left: 0.5em;
+  }
 `;

--- a/fe/src/components/molecules/PriceWithSign/index.tsx
+++ b/fe/src/components/molecules/PriceWithSign/index.tsx
@@ -17,12 +17,23 @@ const getPriceColor = (type: string) => {
       return 'black';
   }
 };
-
+const getSigin = ({ type, price }: { type: string; price: number }) => {
+  if (price === 0) return '';
+  switch (type) {
+    case categoryType.EXPENSE:
+      return '-';
+    case categoryType.INCOME:
+      return '+';
+    default:
+      return '';
+  }
+};
 const PriceWithSign = ({ price, type, ...props }: Prop) => {
   const color = getPriceColor(type);
+  const sign = getSigin({ type, price });
   return (
     <S.Price color={color}>
-      {price === 0 ? '' : `+`}
+      {sign}
       <PriceTag value={price} color={color} {...props} />
     </S.Price>
   );

--- a/fe/src/components/molecules/PriceWithSign/index.tsx
+++ b/fe/src/components/molecules/PriceWithSign/index.tsx
@@ -1,11 +1,11 @@
 import React from 'react';
 import { categoryType } from 'stores/Category';
+import PriceTag, { Props } from 'components/atoms/PriceTag';
 import * as S from './style';
 
-export interface Prop {
+export interface Prop extends Omit<Props, 'value'> {
   price: number;
-  type: 'income' | 'expense' | 'unclassified';
-  children?: any;
+  type: string;
 }
 const getPriceColor = (type: string) => {
   switch (type) {
@@ -18,12 +18,12 @@ const getPriceColor = (type: string) => {
   }
 };
 
-const PriceWithSign = ({ price, type, children }: Prop) => {
+const PriceWithSign = ({ price, type, ...props }: Prop) => {
   const color = getPriceColor(type);
   return (
     <S.Price color={color}>
       {price === 0 ? '' : `+`}
-      {children}
+      <PriceTag value={price} color={color} {...props} />
     </S.Price>
   );
 };

--- a/fe/src/components/molecules/PriceWithSign/index.tsx
+++ b/fe/src/components/molecules/PriceWithSign/index.tsx
@@ -1,0 +1,30 @@
+import React from 'react';
+import { categoryType } from 'stores/Category';
+import * as S from './style';
+
+export interface Prop {
+  price: number;
+  type: 'income' | 'expense' | 'unclassified';
+  children?: any;
+}
+const getPriceColor = (type: string) => {
+  switch (type) {
+    case categoryType.EXPENSE:
+      return 'red';
+    case categoryType.INCOME:
+      return 'brandColor';
+    default:
+      return 'black';
+  }
+};
+
+const PriceWithSign = ({ price, type, children }: Prop) => {
+  const color = getPriceColor(type);
+  return (
+    <S.Price color={color}>
+      {price === 0 ? '' : `+`}
+      {children}
+    </S.Price>
+  );
+};
+export default PriceWithSign;

--- a/fe/src/components/molecules/PriceWithSign/style.ts
+++ b/fe/src/components/molecules/PriceWithSign/style.ts
@@ -1,0 +1,16 @@
+import styled from 'styled-components';
+
+export interface IPrice {
+  color: string;
+  theme: {
+    [propName: string]: any;
+  };
+}
+export const Price = styled.div<IPrice>`
+  display: flex;
+  align-items: center;
+  color: ${({ theme, color }) => theme.color[color]};
+  & + & {
+    margin-left: 0.5em;
+  }
+`;

--- a/fe/src/components/molecules/Transaction/index.tsx
+++ b/fe/src/components/molecules/Transaction/index.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import doubleArrowIcon from 'assets/svg/doubleArrow.svg';
+import PriceWithSign from 'components/molecules/PriceWithSign';
 import * as S from './style';
 
 export interface Props {
@@ -9,6 +10,8 @@ export interface Props {
 
 const Transaction = ({ trans, onClick }: Props) => {
   const classificationString = `${trans.category} | ${trans.method}`;
+  const type = trans.categoryType;
+
   return (
     <S.TransactionStyle onClick={() => onClick(trans.id)}>
       <S.TransactionIcon icon={trans.icon || doubleArrowIcon} size="sm" />
@@ -17,7 +20,7 @@ const Transaction = ({ trans, onClick }: Props) => {
           <S.Client>{trans.client}</S.Client>
           <S.Classification>{classificationString}</S.Classification>
         </S.PaymentInfo>
-        <S.Price value={trans.price} />
+        <PriceWithSign price={trans.price} type={type} />
       </S.Text>
     </S.TransactionStyle>
   );

--- a/fe/src/components/molecules/Transaction/style.ts
+++ b/fe/src/components/molecules/Transaction/style.ts
@@ -1,6 +1,5 @@
 import styled from 'styled-components';
 import Icon from 'components/atoms/Icons';
-import PriceTag from 'components/atoms/PriceTag';
 
 export const TransactionStyle = styled.div`
   box-sizing: border-box;
@@ -32,8 +31,4 @@ export const Classification = styled.div`
   font-size: 0.7rem;
   margin-top: 0.5em;
   color: ${({ theme }) => theme.color.subText};
-`;
-
-export const Price = styled(PriceTag)`
-  margin-left: 0.5rem;
 `;

--- a/fe/src/components/organisms/TransactionList/index.tsx
+++ b/fe/src/components/organisms/TransactionList/index.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import { categoryConvertBig2Small as convert } from 'stores/Category';
 import * as S from './style';
 
 export interface Props {
@@ -10,6 +11,9 @@ export interface Props {
 interface accType {
   transList: JSX.Element[];
   totalPrice: number;
+  income: number;
+  expense: number;
+  unclassified: number;
 }
 
 const TransactionList = ({ date, transactionList, onClick }: Props) => {
@@ -22,6 +26,7 @@ const TransactionList = ({ date, transactionList, onClick }: Props) => {
       />,
     );
     acc.totalPrice += transEl.price;
+    acc[convert(transEl.categoryType)] = transEl.price;
     return acc;
   };
 
@@ -30,6 +35,9 @@ const TransactionList = ({ date, transactionList, onClick }: Props) => {
     {
       transList: [],
       totalPrice: 0,
+      income: 0,
+      expense: 0,
+      unclassified: 0,
     },
   );
 

--- a/fe/src/components/organisms/TransactionList/index.tsx
+++ b/fe/src/components/organisms/TransactionList/index.tsx
@@ -30,20 +30,29 @@ const TransactionList = ({ date, transactionList, onClick }: Props) => {
     return acc;
   };
 
-  const { transList, totalPrice } = transactionList.reduce(
-    reduceTransactionList,
-    {
-      transList: [],
-      totalPrice: 0,
-      income: 0,
-      expense: 0,
-      unclassified: 0,
-    },
-  );
+  const {
+    transList,
+    totalPrice,
+    income,
+    expense,
+    unclassified,
+  } = transactionList.reduce(reduceTransactionList, {
+    transList: [],
+    totalPrice: 0,
+    income: 0,
+    expense: 0,
+    unclassified: 0,
+  });
 
   return (
     <S.TransactionList>
-      <S.Header date={date} totalPayment={totalPrice} />
+      <S.Header
+        date={date}
+        totalPayment={totalPrice}
+        income={income}
+        expense={expense}
+        unclassified={unclassified}
+      />
       {transList}
     </S.TransactionList>
   );

--- a/fe/src/stores/Category/index.ts
+++ b/fe/src/stores/Category/index.ts
@@ -57,7 +57,7 @@ const categoryConverter = (input: string): string => {
       return categoryType.UNCLASSIFIED;
   }
 };
-export const categoryConvertBig2Small = (input: string): string => {
+export const categoryConvertBig2Small = (input: string) => {
   switch (input) {
     case categoryType.EXPENSE:
     case 'expense':

--- a/fe/src/stores/Transaction/index.ts
+++ b/fe/src/stores/Transaction/index.ts
@@ -158,10 +158,9 @@ export const TransactionStore = makeAutoObservable({
     return calTotalPriceByDateAndType(this.transactions, categoryType.EXPENSE);
   },
   get totalPrices(): { income: number; expense: number } {
-    if (this.isFiltered) {
-      return sumAllPricesByType(this.filteredTransactionList);
-    }
-    return calTotalPrices(this.getTransactions());
+    return this.isFiltered
+      ? sumAllPricesByType(this.filteredTransactionList)
+      : calTotalPrices(this.getTransactions());
   },
   get filteredTransactionList(): types.TransactionDBType[] {
     if (!this.isFiltered) return [];

--- a/fe/src/stores/Transaction/transactionStoreUtils.ts
+++ b/fe/src/stores/Transaction/transactionStoreUtils.ts
@@ -1,18 +1,18 @@
 import math from 'utils/math';
 import { IDateTotalprice, TransactionDBType, IDateTransactionObj } from 'types';
 import { TransactionStore } from 'stores/Transaction';
-import { categoryConvertBig2Small, categoryType } from 'stores/Category';
+import { categoryConvertBig2Small } from 'stores/Category';
 import dateUtil from 'utils/date';
 
 export const initTotalPrice = {
   income: 0,
   expense: 0,
+  unclassified: 0,
 };
 
 export const sumAllPricesByType = (transactions: TransactionDBType[]) => {
   return transactions.reduce((summedPriceByType, transaction) => {
-    const type =
-      transaction.category.type === categoryType.INCOME ? 'income' : 'expense';
+    const type = categoryConvertBig2Small(transaction.category.type);
     return {
       ...summedPriceByType,
       [type]: summedPriceByType[type] + transaction.price,

--- a/fe/src/stores/Transaction/transactionStoreUtils.ts
+++ b/fe/src/stores/Transaction/transactionStoreUtils.ts
@@ -48,6 +48,7 @@ export const convertTransactionDBTypetoTransactionType = (input: any[]) => {
         id: _id,
         category: category.title,
         method: method.title,
+        categoryType: category.type,
       },
     ];
   }, []);

--- a/fe/src/stores/Transaction/transactionStoreUtils.ts
+++ b/fe/src/stores/Transaction/transactionStoreUtils.ts
@@ -55,11 +55,12 @@ export const convertTransactionDBTypetoTransactionType = (input: any[]) => {
 
 export const calTotalPrices = (list: IDateTransactionObj) => {
   return Object.values<TransactionDBType[]>(list).reduce(
-    (acc: { income: number; expense: number }, transactions) => {
+    (acc, transactions) => {
       const summedPrices = sumAllPricesByType(transactions);
       return {
         income: acc.income + summedPrices.income,
         expense: acc.expense + summedPrices.expense,
+        unclassified: acc.unclassified + summedPrices.unclassified,
       };
     },
     initTotalPrice,


### PR DESCRIPTION
## [변경사항](https://github.com/boostcamp-2020/Project16-A-Account-Book/pull/246/files/ea20d5154ce63b250a5b358ef800ae5eca31d894..709fc054126ccf8e64b821e2164e5728147d570b)
<img src='https://user-images.githubusercontent.com/44409642/102252972-19540a80-3f4a-11eb-87de-28c0995c162b.png' width ='300'/>

기존 메인 페이지에서 항목이 지출인지 수입인지 구별이 잘 안되어서 가격에 색상을 차별하였습니다. 
그리고 미분류 태그는 합계에 안들어 가도록 수정하였습니다. 

## 멘토님들

@boostcamp-2020/accountbook_mentor
