### PR TITLE
[FE] Fix: 파이차트 계산할 때, 가격 순으로 내림차순 정렬할 수 있도록 수정

### DIFF
--- a/fe/src/stores/Transaction/index.ts
+++ b/fe/src/stores/Transaction/index.ts
@@ -1,6 +1,7 @@
 import { makeAutoObservable, runInAction, toJS } from 'mobx';
 import transactionAPI from 'apis/transaction';
 import date from 'utils/date';
+import mathUtils from 'utils/math';
 import { categoryType } from 'stores/Category';
 import * as types from 'types';
 import {
@@ -179,14 +180,18 @@ export const TransactionStore = makeAutoObservable({
   get pieChartStatistics(): types.IStatistics {
     const totalPrice = this.totalPricesExceptFilterAndUnclassified;
     const totalCategoryObj = calTotalPriceByCategories(this.transactionList);
-    const incomeCategories = addPercentAndGetArray(
+    const incomeArray = addPercentAndGetArray(
       totalCategoryObj.totalIncomeCategoryObj,
       totalPrice.income,
     );
-    const expenseCategories = addPercentAndGetArray(
+    const expenseArray = addPercentAndGetArray(
       totalCategoryObj.totalExpenseCategoryObj,
       totalPrice.expense,
     );
+    const compByTotalPrice = mathUtils.getCompFuncByKey('totalPrice', false);
+    const incomeCategories = incomeArray.sort(compByTotalPrice);
+    const expenseCategories = expenseArray.sort(compByTotalPrice);
+
     return { totalPrice, incomeCategories, expenseCategories };
   },
   getTransactions(): types.IDateTransactionObj {


### PR DESCRIPTION
## 변경사항
<img width="343" alt="스크린샷 2020-12-16 오후 8 21 39" src="https://user-images.githubusercontent.com/43772082/102342242-5072fc00-3fdc-11eb-9d2f-6cc46de750ec.png">

기존에는 총 금액 별로 정렬이 되어있지 않은 문제가 있었습니다.
총 금액인 totalPrice기준으로 내림차순 정렬한 순으로 보여주도록 수정하였습니다.

## 체크리스트
- [ ] 큰 금액 순으로 카테고리가 정렬되어 보여진다.

## Linked Issues
closes #255 
## 멘토님들

@boostcamp-2020/accountbook_mentor
