### PR TITLE
거래내역 수정시 원래 카테고리, 결제내역을 디폴트로 설정

### DIFF
--- a/fe/src/components/organisms/TransactionInputField/index.tsx
+++ b/fe/src/components/organisms/TransactionInputField/index.tsx
@@ -22,8 +22,10 @@ export interface Props {
   client: string;
   memo: string;
   classifications: string[];
-  formHandler: any;
   price: number;
+  category: string;
+  method: string;
+  formHandler: any;
 }
 
 const TransactionInputField = ({
@@ -34,6 +36,8 @@ const TransactionInputField = ({
   memo,
   formHandler,
   price,
+  category,
+  method,
 }: Props): React.ReactElement => {
   const methods = MethodStore.getMethods();
   const categories = CategoryStore.getCategories(classification);
@@ -64,9 +68,13 @@ const TransactionInputField = ({
       </LabelWrap>
       <LabelWrap htmlFor={CATEGORY} title="카테고리">
         <select name={CATEGORY} id={CATEGORY} onChange={formHandler}>
-          {categories.map((category) => (
-            <option key={category._id} value={category._id}>
-              {category.title}
+          {categories.map((categoryItem) => (
+            <option
+              key={categoryItem._id}
+              value={categoryItem._id}
+              selected={category === categoryItem._id}
+            >
+              {categoryItem.title}
             </option>
           ))}
         </select>
@@ -81,11 +89,15 @@ const TransactionInputField = ({
       </LabelWrap>
       <LabelWrap htmlFor={METHOD} title="결제수단">
         <select name={METHOD} id={METHOD} onChange={formHandler}>
-          {methods.map((method) => {
-            if (method.title === '미분류') return <></>;
+          {methods.map((methodItem) => {
+            if (methodItem.title === '미분류') return <></>;
             return (
-              <option key={method._id} value={method._id}>
-                {method.title}
+              <option
+                key={methodItem._id}
+                value={methodItem._id}
+                selected={method === methodItem._id}
+              >
+                {methodItem.title}
               </option>
             );
           })}

--- a/fe/src/hooks/useTransactionInput.ts
+++ b/fe/src/hooks/useTransactionInput.ts
@@ -20,7 +20,7 @@ const initState = {
   memo: '',
   price: 0,
   classification: '지출',
-  category: '미분류',
+  category: '',
   method: '',
 };
 const useTransactionInput = (transactionObjId?: string): [State, any] => {
@@ -32,16 +32,14 @@ const useTransactionInput = (transactionObjId?: string): [State, any] => {
       [name]: value,
     }));
   };
-  const loadAndSetInitialMethod = async () => {
-    await MethodStore.loadMethods();
+  const setInitialMethod = () => {
     const initialMethod = MethodStore.getMethods()[0];
     setTransaction((prevState) => ({
       ...prevState,
       method: initialMethod._id,
     }));
   };
-  const loadAndSetInitialCategory = async () => {
-    await CategoryStore.loadCategories();
+  const setInitialCategory = () => {
     const initialCategory = CategoryStore.getCategories(
       transactionState.classification,
     )[0];
@@ -49,6 +47,13 @@ const useTransactionInput = (transactionObjId?: string): [State, any] => {
       ...prevState,
       category: initialCategory._id,
     }));
+  };
+
+  const loadCategoryMethod = async () => {
+    await Promise.all([
+      CategoryStore.loadCategories(),
+      MethodStore.loadMethods(),
+    ]);
   };
 
   const loadTransactionAndSetInitialInput = async () => {
@@ -77,10 +82,12 @@ const useTransactionInput = (transactionObjId?: string): [State, any] => {
     }));
   }, [transactionState.classification]);
   useEffect(() => {
-    loadAndSetInitialCategory();
-    loadAndSetInitialMethod();
+    loadCategoryMethod();
     if (transactionObjId) {
       loadTransactionAndSetInitialInput();
+    } else {
+      setInitialCategory();
+      setInitialMethod();
     }
   }, []);
   return [transactionState, setInputState];

--- a/fe/src/pages/CreateTransactionPage/index.tsx
+++ b/fe/src/pages/CreateTransactionPage/index.tsx
@@ -15,13 +15,8 @@ const CreateTransacionPage = () => {
   const [transactionState, setInputState] = useTransactionInput();
   const history = useHistory();
 
-  const { date, client, memo, price, classification } = transactionState;
   const inputFieldProps = {
-    date,
-    client,
-    memo,
-    price,
-    classification,
+    ...transactionState,
     classifications,
     formHandler: setInputState,
   };

--- a/fe/src/pages/UpdateTransactionPage/index.tsx
+++ b/fe/src/pages/UpdateTransactionPage/index.tsx
@@ -17,14 +17,8 @@ const UpdateTransacionPage = ({ location }: { location: any }) => {
     transactionObjId as string,
   );
   const history = useHistory();
-
-  const { date, client, memo, price, classification } = transactionState;
   const inputFieldProps = {
-    date,
-    client,
-    memo,
-    price,
-    classification,
+    ...transactionState,
     classifications,
     formHandler: setInputState,
   };
@@ -60,7 +54,6 @@ const UpdateTransacionPage = ({ location }: { location: any }) => {
       onDelete={onDeleteHandler}
     />
   );
-
   return (
     <FormTransactionTemplate
       header={<Header title="거래내역 수정" back />}


### PR DESCRIPTION
## 변경사항

![2020-12-16 21 56 03](https://user-images.githubusercontent.com/43772082/102351331-9c786d80-3fe9-11eb-93f8-ac53ee187784.gif)


결제내역 수정 시 원래 있던 카테고리와 결제수단을 디폴트로 두기 위해,
카테고리와 결제수단 리스트 중에서 원래 설정된 값과 일치하는 것은 
option Tag에 selected를 추가하였습니다.

추가로, useTransactionInput hook에서 초기값 설정 하는 부분에서
거래내역이 ''로 설정되었다가 'somethingId'로 설정되면, 렌더링 시 초기값이 ''로 되므로,
수정이라면 ''로 설정하는 것 없이 바로 'somethingId'로 설정하였습니다.

## 체크리스트
- [ ] 거래내역 수정시, 원래의 카테고리와 결제수단이 디폴트값으로 설정되어있다.

## Linked Issues
closes #259 

## 멘토님들

@boostcamp-2020/accountbook_mentor
