### PR TITLE
라인차트에서 y좌표의 단위 변경

### DIFF
--- a/fe/src/components/molecules/LineChart/index.tsx
+++ b/fe/src/components/molecules/LineChart/index.tsx
@@ -23,7 +23,7 @@ const LineChart = ({
   const FONT_SIZE = width / 60;
   const maximumXFromData = data.length;
   const maximumYFromData = Math.max(...data.map((e) => e.totalPrice));
-  const digits = utils.moneyFormatter(maximumYFromData).length;
+  const digits = utils.summaryOfMoney(maximumYFromData).length;
 
   const paddingLeftWidth = (FONT_SIZE + digits) * 3;
   const paddingHeight = FONT_SIZE * 3;
@@ -129,14 +129,14 @@ const LineChart = ({
     return (
       <>
         {new Array(PARTS + 1).fill(0).map((_, index) => {
-          const x = FONT_SIZE;
+          const x = FONT_SIZE / 2;
           const ratio = index / numberOfHorizontalGuides;
           const y = getYpos(ratio) + FONT_SIZE / 2;
+          const money = Math.round(maximumYFromData * (index / PARTS));
+          const label = utils.summaryOfMoney(money);
           return (
             <text key={`label-y-${y}`} x={x} y={y} style={labelStyle}>
-              {utils.moneyFormatter(
-                Math.round(maximumYFromData * (index / PARTS)),
-              )}
+              {label}
             </text>
           );
         })}

--- a/fe/src/components/molecules/PieChart/index.stories.tsx
+++ b/fe/src/components/molecules/PieChart/index.stories.tsx
@@ -9,18 +9,25 @@ export default {
 export const SimplePieChart = () => {
   const pieces = [
     {
-      title: '기타수입',
-      color: '#be00a5',
-      _id: '5fc79e46233d1b4e239f28df',
-      totalPrice: 1445389,
-      percent: 70,
-    },
-    {
       title: '사업수입',
       color: '#dded7e',
       _id: '5fc79e46233d1b4e239f28de',
       totalPrice: 803999,
       percent: 10,
+    },
+    {
+      title: '기타',
+      color: 'red',
+      _id: '5fc79e46233d1b48df',
+      totalPrice: 1445389,
+      percent: 80,
+    },
+    {
+      title: '기타수입',
+      color: '#be00a5',
+      _id: '5fc79e46233d1b4e239f28df',
+      totalPrice: 1445389,
+      percent: 6,
     },
   ];
   return (

--- a/fe/src/components/organisms/TransactionForm/index.stories.tsx
+++ b/fe/src/components/organisms/TransactionForm/index.stories.tsx
@@ -11,9 +11,7 @@ export default {
   decorators: [withKnobs],
 };
 export const Transaction = () => {
-  const categories = ['미분류', '급여', '용돈', '금융수입'];
-  const methods = ['현금', '카드', '카카오뱅크', '네이버페이'];
-  const classifications = ['지출', '수입', '이체'];
+  const classifications = ['지출', '수입'];
 
   const [formValue, setFormValue] = useState({
     date: dayjs(new Date()).format('YYYY-MM-DD'),
@@ -21,7 +19,7 @@ export const Transaction = () => {
     memo: '',
     price: 0,
     classification: '',
-    category: '미분류',
+    category: '',
     method: '',
   });
 
@@ -35,13 +33,7 @@ export const Transaction = () => {
     alert('save');
   };
   const inputFieldProps = {
-    date: formValue.date,
-    client: formValue.client,
-    memo: formValue.memo,
-    price: formValue.price,
-    classification: formValue.classification,
-    categories,
-    methods,
+    ...formValue,
     classifications,
     formHandler,
   };

--- a/fe/src/components/organisms/TransactionInputField/index.stories.tsx
+++ b/fe/src/components/organisms/TransactionInputField/index.stories.tsx
@@ -14,7 +14,7 @@ export const Transaction = () => {
   const classifications = ['지출', '수입'];
 
   const [formValue, setFormValue] = useState({
-    category: '미분류',
+    category: '',
     date: dayjs(new Date()).format('YYYY-MM-DD'),
     client: '',
     memo: '',
@@ -38,6 +38,8 @@ export const Transaction = () => {
         client={formValue.client}
         memo={formValue.memo}
         formHandler={formHandler}
+        method={formValue.method}
+        category={formValue.category}
       />
     </ThemeProvider>
   );

--- a/fe/src/components/organisms/TransactionInputField/index.tsx
+++ b/fe/src/components/organisms/TransactionInputField/index.tsx
@@ -22,8 +22,10 @@ export interface Props {
   client: string;
   memo: string;
   classifications: string[];
-  formHandler: any;
   price: number;
+  category: string;
+  method: string;
+  formHandler: any;
 }
 
 const TransactionInputField = ({
@@ -34,6 +36,8 @@ const TransactionInputField = ({
   memo,
   formHandler,
   price,
+  category,
+  method,
 }: Props): React.ReactElement => {
   const methods = MethodStore.getMethods();
   const categories = CategoryStore.getCategories(classification);
@@ -64,9 +68,13 @@ const TransactionInputField = ({
       </LabelWrap>
       <LabelWrap htmlFor={CATEGORY} title="카테고리">
         <select name={CATEGORY} id={CATEGORY} onChange={formHandler}>
-          {categories.map((category) => (
-            <option key={category._id} value={category._id}>
-              {category.title}
+          {categories.map((categoryItem) => (
+            <option
+              key={categoryItem._id}
+              value={categoryItem._id}
+              selected={category === categoryItem._id}
+            >
+              {categoryItem.title}
             </option>
           ))}
         </select>
@@ -81,11 +89,15 @@ const TransactionInputField = ({
       </LabelWrap>
       <LabelWrap htmlFor={METHOD} title="결제수단">
         <select name={METHOD} id={METHOD} onChange={formHandler}>
-          {methods.map((method) => {
-            if (method.title === '미분류') return <></>;
+          {methods.map((methodItem) => {
+            if (methodItem.title === '미분류') return <></>;
             return (
-              <option key={method._id} value={method._id}>
-                {method.title}
+              <option
+                key={methodItem._id}
+                value={methodItem._id}
+                selected={method === methodItem._id}
+              >
+                {methodItem.title}
               </option>
             );
           })}

--- a/fe/src/hooks/useTransactionInput.ts
+++ b/fe/src/hooks/useTransactionInput.ts
@@ -20,7 +20,7 @@ const initState = {
   memo: '',
   price: 0,
   classification: '지출',
-  category: '미분류',
+  category: '',
   method: '',
 };
 const useTransactionInput = (transactionObjId?: string): [State, any] => {
@@ -32,16 +32,14 @@ const useTransactionInput = (transactionObjId?: string): [State, any] => {
       [name]: value,
     }));
   };
-  const loadAndSetInitialMethod = async () => {
-    await MethodStore.loadMethods();
+  const setInitialMethod = () => {
     const initialMethod = MethodStore.getMethods()[0];
     setTransaction((prevState) => ({
       ...prevState,
       method: initialMethod._id,
     }));
   };
-  const loadAndSetInitialCategory = async () => {
-    await CategoryStore.loadCategories();
+  const setInitialCategory = () => {
     const initialCategory = CategoryStore.getCategories(
       transactionState.classification,
     )[0];
@@ -49,6 +47,13 @@ const useTransactionInput = (transactionObjId?: string): [State, any] => {
       ...prevState,
       category: initialCategory._id,
     }));
+  };
+
+  const loadCategoryMethod = async () => {
+    await Promise.all([
+      CategoryStore.loadCategories(),
+      MethodStore.loadMethods(),
+    ]);
   };
 
   const loadTransactionAndSetInitialInput = async () => {
@@ -77,10 +82,12 @@ const useTransactionInput = (transactionObjId?: string): [State, any] => {
     }));
   }, [transactionState.classification]);
   useEffect(() => {
-    loadAndSetInitialCategory();
-    loadAndSetInitialMethod();
+    loadCategoryMethod();
     if (transactionObjId) {
       loadTransactionAndSetInitialInput();
+    } else {
+      setInitialCategory();
+      setInitialMethod();
     }
   }, []);
   return [transactionState, setInputState];

--- a/fe/src/pages/CreateTransactionPage/index.tsx
+++ b/fe/src/pages/CreateTransactionPage/index.tsx
@@ -15,13 +15,8 @@ const CreateTransacionPage = () => {
   const [transactionState, setInputState] = useTransactionInput();
   const history = useHistory();
 
-  const { date, client, memo, price, classification } = transactionState;
   const inputFieldProps = {
-    date,
-    client,
-    memo,
-    price,
-    classification,
+    ...transactionState,
     classifications,
     formHandler: setInputState,
   };

--- a/fe/src/pages/UpdateTransactionPage/index.tsx
+++ b/fe/src/pages/UpdateTransactionPage/index.tsx
@@ -17,14 +17,8 @@ const UpdateTransacionPage = ({ location }: { location: any }) => {
     transactionObjId as string,
   );
   const history = useHistory();
-
-  const { date, client, memo, price, classification } = transactionState;
   const inputFieldProps = {
-    date,
-    client,
-    memo,
-    price,
-    classification,
+    ...transactionState,
     classifications,
     formHandler: setInputState,
   };
@@ -60,7 +54,6 @@ const UpdateTransacionPage = ({ location }: { location: any }) => {
       onDelete={onDeleteHandler}
     />
   );
-
   return (
     <FormTransactionTemplate
       header={<Header title="거래내역 수정" back />}

--- a/fe/src/utils/__tests__/money.test.ts
+++ b/fe/src/utils/__tests__/money.test.ts
@@ -1,6 +1,11 @@
 import utils from '../index';
 
 describe('금액이 주어졌을 때,', () => {
+  test('천원대 미만의 금액은 그대로 돌아온다.', () => {
+    expect(utils.summaryOfMoney(-1000)).toBe('-1000');
+    expect(utils.summaryOfMoney(0)).toBe('0');
+    expect(utils.summaryOfMoney(123)).toBe('123');
+  });
   test('천원대의 금액이 들어오면 X.X천을 반환한다.', () => {
     expect(utils.summaryOfMoney(4500)).toBe('4.5천');
   });

--- a/fe/src/utils/__tests__/money.test.ts
+++ b/fe/src/utils/__tests__/money.test.ts
@@ -1,0 +1,34 @@
+import utils from '../index';
+
+describe('금액이 주어졌을 때,', () => {
+  test('천원대의 금액이 들어오면 X.X천을 반환한다.', () => {
+    expect(utils.summaryOfMoney(4500)).toBe('4.5천');
+  });
+  test('만원대의 금액이 들어오면 X.X만을 반환한다.', () => {
+    expect(utils.summaryOfMoney(11000)).toBe('1.1만');
+  });
+  test('십만원대의 금액이 들어오면 X.X십만을 반환한다.', () => {
+    expect(utils.summaryOfMoney(490000)).toBe('4.9십만');
+  });
+  test('백만원대의 금액이 들어오면 X.X백만을 반환한다.', () => {
+    expect(utils.summaryOfMoney(1200040)).toBe('1.2백만');
+  });
+  test('천만원대의 금액이 들어오면 X.X천만을 반환한다.', () => {
+    expect(utils.summaryOfMoney(26000400)).toBe('2.6천만');
+  });
+  test('억대의 금액이 들어오면 X.X억을 반환한다.', () => {
+    expect(utils.summaryOfMoney(560000400)).toBe('5.6억');
+  });
+  test('십억대의 금액이 들어오면 X.X십억을 반환한다.', () => {
+    expect(utils.summaryOfMoney(1234004000)).toBe('1.2십억');
+  });
+  test('백대의 금액이 들어오면 X.X백억을 반환한다.', () => {
+    expect(utils.summaryOfMoney(43240040000)).toBe('4.3백억');
+  });
+  test('천억대의 금액이 들어오면 X.X천억을 반환한다.', () => {
+    expect(utils.summaryOfMoney(632400400000)).toBe('6.3천억');
+  });
+  test('조의 금액이 들어오면 X.X천억을 반환한다.', () => {
+    expect(utils.summaryOfMoney(9824004000000)).toBe('98.2천억');
+  });
+});

--- a/fe/src/utils/index.ts
+++ b/fe/src/utils/index.ts
@@ -11,4 +11,33 @@ export default {
     }
     return [...set];
   },
+  summaryOfMoney(money: number): string {
+    const NUM_OF_DECIMAL_PLACE = 1;
+    const matcher = [
+      [10 ** 3, '천'],
+      [10 ** 4, '만'],
+      [10 ** 5, '십만'],
+      [10 ** 6, '백만'],
+      [10 ** 7, '천만'],
+      [10 ** 8, '억'],
+      [10 ** 9, '십억'],
+      [10 ** 10, '백억'],
+      [10 ** 11, '천억'],
+    ];
+    let matched;
+
+    type matcherType = [divisionBy: number | any, unit: string];
+    // eslint-disable-next-line no-restricted-syntax
+    for (const matcherItem of matcher) {
+      const [divisionBy, unit] = matcherItem as matcherType;
+      if (Math.floor(money / divisionBy) === 0) {
+        break;
+      }
+      matched = [divisionBy, unit];
+    }
+    const [matchedDivisitonBy, matchedUnit] = matched;
+    return `${Number.parseFloat(`${money / matchedDivisitonBy}`).toFixed(
+      NUM_OF_DECIMAL_PLACE,
+    )}${matchedUnit}`;
+  },
 };

--- a/fe/src/utils/index.ts
+++ b/fe/src/utils/index.ts
@@ -12,6 +12,9 @@ export default {
     return [...set];
   },
   summaryOfMoney(money: number): string {
+    if (money < 1000) {
+      return String(money);
+    }
     const NUM_OF_DECIMAL_PLACE = 1;
     const matcher = [
       [10 ** 3, '천'],
@@ -24,7 +27,8 @@ export default {
       [10 ** 10, '백억'],
       [10 ** 11, '천억'],
     ];
-    let matched;
+    let matchedDivisitonBy;
+    let matchedUnit;
 
     type matcherType = [divisionBy: number | any, unit: string];
     // eslint-disable-next-line no-restricted-syntax
@@ -33,9 +37,9 @@ export default {
       if (Math.floor(money / divisionBy) === 0) {
         break;
       }
-      matched = [divisionBy, unit];
+      matchedDivisitonBy = divisionBy;
+      matchedUnit = unit;
     }
-    const [matchedDivisitonBy, matchedUnit] = matched;
     return `${Number.parseFloat(`${money / matchedDivisitonBy}`).toFixed(
       NUM_OF_DECIMAL_PLACE,
     )}${matchedUnit}`;


### PR DESCRIPTION
## [🔗변경사항](https://github.com/boostcamp-2020/Project16-A-Account-Book/pull/269/files/2b9519384e54f1bc0c4954fdc399ab3f2c63c96f..ac252c71e0411b736dd5159cef8fb83bedc281a3)
<img width="337" alt="스크린샷 2020-12-17 오전 12 12 36" src="https://user-images.githubusercontent.com/43772082/102367271-e9b20a80-3ffc-11eb-9d1c-94fe36924c73.png">


y좌표의의 돈 단위를 요약해서 보여주기 위해
1000원은 1.0천원으로 만들어주는 유틸함수를 구현하여, y좌표를 요약하여 표현해보았습니다.

## 논의하고 싶은 점
- 현재 이 함수는 천억까지 커버를 할 수 있도록 하였습니다.
단위를 더 만드는 것은 어려운 일이 아니지만, 
어느 정도의  돈의 단위를 넘어가는 수준에서는 거래내역에서 입력을 하지 못하도록 
막는것은 어떨까요?
<img width="318" alt="스크린샷 2020-12-17 오전 12 16 33" src="https://user-images.githubusercontent.com/43772082/102367441-21b94d80-3ffd-11eb-9024-3ce45d2db3ec.png">

## 체크리스트
- [ ] 라인차트의 y좌표의 단위가 요약해서 보여진다.

## Linked Issues
closes #121

## 멘토님들

@boostcamp-2020/accountbook_mentor
