### PR TITLE
IOS 에서 안들어가지는 버그 수정 및 price 수정

### DIFF
--- a/fe/package.json
+++ b/fe/package.json
@@ -64,7 +64,7 @@
       "last 1 safari version"
     ]
   },
-  "proxy": "http://localhost:4000",
+  "proxy": "http://180.189.86.196:4000",
   "devDependencies": {
     "@babel/core": "^7.12.3",
     "@storybook/addon-actions": "^6.0.28",

--- a/fe/package.json
+++ b/fe/package.json
@@ -64,7 +64,7 @@
       "last 1 safari version"
     ]
   },
-  "proxy": "http://180.189.86.196:4000",
+  "proxy": "http://localhost:4000",
   "devDependencies": {
     "@babel/core": "^7.12.3",
     "@storybook/addon-actions": "^6.0.28",

--- a/fe/src/components/atoms/DatePicker/index.tsx
+++ b/fe/src/components/atoms/DatePicker/index.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import ReactDatePicker, {
-  registerLocale,
   setDefaultLocale,
+  registerLocale,
 } from 'react-datepicker';
 import 'react-datepicker/dist/react-datepicker.css';
 import ko from 'date-fns/locale/ko';

--- a/fe/src/components/atoms/PriceTag/index.tsx
+++ b/fe/src/components/atoms/PriceTag/index.tsx
@@ -17,7 +17,7 @@ const PriceTag: React.FC<Props> = ({
 }): React.ReactElement => {
   return (
     <PriceContainer bold={bold} size={size} color={color} {...props}>
-      {value === 0 ? '' : `${value.toLocaleString()}원`}
+      {`${value.toLocaleString()}원`}
     </PriceContainer>
   );
 };

--- a/fe/src/components/organisms/MonthInfoHeader/index.tsx
+++ b/fe/src/components/organisms/MonthInfoHeader/index.tsx
@@ -3,8 +3,8 @@ import TotalBox from 'components/molecules/TotalBox';
 import { Link, useParams } from 'react-router-dom';
 import { observer } from 'mobx-react-lite';
 import { TransactionStore } from 'stores/Transaction';
-import dateUtils from 'utils/date';
 import DateRange from 'components/molecules/DateRange';
+import dayjs from 'dayjs';
 import * as S from './style';
 
 interface MonthInfoHeaderInterface {
@@ -23,9 +23,9 @@ type Params = {
 const MonthInfoHeader = ({
   date = {
     startDate: TransactionStore.getOriginDates().startDate,
-    endDate: new Date(
-      dateUtils.subTractDate(TransactionStore.getDates().endDate),
-    ),
+    endDate: dayjs(TransactionStore.getDates().endDate)
+      .subtract(1, 'date')
+      .toDate(),
   },
   total = TransactionStore.totalPrices,
 }: MonthInfoHeaderInterface) => {

--- a/fe/src/components/organisms/TransactionList/index.tsx
+++ b/fe/src/components/organisms/TransactionList/index.tsx
@@ -26,7 +26,7 @@ const TransactionList = ({ date, transactionList, onClick }: Props) => {
       />,
     );
     acc.totalPrice += transEl.price;
-    acc[convert(transEl.categoryType)] = transEl.price;
+    acc[convert(transEl.categoryType)] += transEl.price;
     return acc;
   };
 

--- a/fe/src/stores/Transaction/index.ts
+++ b/fe/src/stores/Transaction/index.ts
@@ -31,10 +31,7 @@ export interface ITransactionStore {
   modalDate: Date;
 }
 
-const oneMonthDate = date.getOneMonthRange(
-  String(new Date().getFullYear()),
-  String(new Date().getMonth() + 1),
-);
+const oneMonthDate = date.getOneMonthRange();
 
 const initialState: ITransactionStore = {
   transactions: {},

--- a/fe/src/utils/date.ts
+++ b/fe/src/utils/date.ts
@@ -1,7 +1,10 @@
 import dayjs from 'dayjs';
 import 'dayjs/locale/ko';
+import utc from 'dayjs/plugin/utc';
 
+dayjs.extend(utc);
 dayjs.locale('ko');
+
 export default {
   dateFormatter: (date: Date): string => dayjs(date).format('YYYY-MM-DD'),
   dateCustomFormatter: (date: Date | string | number, format: string): string =>
@@ -10,16 +13,12 @@ export default {
     const nowMaxDate = new Date(date.getFullYear(), date.getMonth() + 1, -1);
     return nowMaxDate.getDate() + 1;
   },
-  getOneMonthRange: (year: string, month: string) => {
-    if (month === '12') {
-      return {
-        startDate: new Date(`${year}-${month}-1`),
-        endDate: new Date(`${Number(year) + 1}-${1}`),
-      };
-    }
+  getOneMonthRange: () => {
+    const now = dayjs().set('date', 1);
+    const endDate = now.add(1, 'month');
     return {
-      startDate: new Date(`${year}-${month}-1`),
-      endDate: new Date(`${year}-${Number(month) + 1}`),
+      startDate: now.toDate(),
+      endDate: endDate.toDate(),
     };
   },
   getNextDate: (date: Date | string) =>


### PR DESCRIPTION
## 변경사항
초반에 `startDate, endDate` 지정하는 부분에서 IOS에서 지원하지않는 타입으로 에러가 출력되었습니다. 
dayjs 를 사용하여 UTC로 통일하여 초기값 셋팅을 하였습니다.

## Linked Issues
closes #274 
closes #238 
## 멘토님들

@boostcamp-2020/accountbook_mentor
