### PR TITLE
기기에 맞는 width, font-size 수정

### DIFF
--- a/fe/package.json
+++ b/fe/package.json
@@ -64,7 +64,7 @@
       "last 1 safari version"
     ]
   },
-  "proxy": "http://localhost:4000",
+  "proxy": "http://180.189.86.196:4000",
   "devDependencies": {
     "@babel/core": "^7.12.3",
     "@storybook/addon-actions": "^6.0.28",

--- a/fe/package.json
+++ b/fe/package.json
@@ -64,7 +64,7 @@
       "last 1 safari version"
     ]
   },
-  "proxy": "http://180.189.86.196:4000",
+  "proxy": "http://localhost:4000",
   "devDependencies": {
     "@babel/core": "^7.12.3",
     "@storybook/addon-actions": "^6.0.28",

--- a/fe/src/components/atoms/DatePicker/index.tsx
+++ b/fe/src/components/atoms/DatePicker/index.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import ReactDatePicker, {
-  registerLocale,
   setDefaultLocale,
+  registerLocale,
 } from 'react-datepicker';
 import 'react-datepicker/dist/react-datepicker.css';
 import ko from 'date-fns/locale/ko';

--- a/fe/src/components/atoms/PriceTag/index.tsx
+++ b/fe/src/components/atoms/PriceTag/index.tsx
@@ -17,7 +17,7 @@ const PriceTag: React.FC<Props> = ({
 }): React.ReactElement => {
   return (
     <PriceContainer bold={bold} size={size} color={color} {...props}>
-      {value === 0 ? '' : `${value.toLocaleString()}원`}
+      {`${value.toLocaleString()}원`}
     </PriceContainer>
   );
 };

--- a/fe/src/components/organisms/MonthInfoHeader/index.tsx
+++ b/fe/src/components/organisms/MonthInfoHeader/index.tsx
@@ -3,8 +3,8 @@ import TotalBox from 'components/molecules/TotalBox';
 import { Link, useParams } from 'react-router-dom';
 import { observer } from 'mobx-react-lite';
 import { TransactionStore } from 'stores/Transaction';
-import dateUtils from 'utils/date';
 import DateRange from 'components/molecules/DateRange';
+import dayjs from 'dayjs';
 import * as S from './style';
 
 interface MonthInfoHeaderInterface {
@@ -23,9 +23,9 @@ type Params = {
 const MonthInfoHeader = ({
   date = {
     startDate: TransactionStore.getOriginDates().startDate,
-    endDate: new Date(
-      dateUtils.subTractDate(TransactionStore.getDates().endDate),
-    ),
+    endDate: dayjs(TransactionStore.getDates().endDate)
+      .subtract(1, 'date')
+      .toDate(),
   },
   total = TransactionStore.totalPrices,
 }: MonthInfoHeaderInterface) => {

--- a/fe/src/components/organisms/TransactionList/index.tsx
+++ b/fe/src/components/organisms/TransactionList/index.tsx
@@ -26,7 +26,7 @@ const TransactionList = ({ date, transactionList, onClick }: Props) => {
       />,
     );
     acc.totalPrice += transEl.price;
-    acc[convert(transEl.categoryType)] = transEl.price;
+    acc[convert(transEl.categoryType)] += transEl.price;
     return acc;
   };
 

--- a/fe/src/components/templates/CategoryTemplate/index.tsx
+++ b/fe/src/components/templates/CategoryTemplate/index.tsx
@@ -4,22 +4,21 @@ import * as S from './style';
 
 interface Props {
   headerContent: React.ReactNode;
-  title: React.ReactNode;
   bodyContent: React.ReactNode;
   NavBar: React.ReactNode;
 }
 
 function CategoryTemplate({
   headerContent,
-  title,
   bodyContent,
   NavBar,
 }: Props): React.ReactElement {
   return (
     <S.CategoryContainer>
       <S.CategoryHeader>{headerContent}</S.CategoryHeader>
-      <S.CategoryTitle>{title}</S.CategoryTitle>
-      <S.CategoryBody>{bodyContent}</S.CategoryBody>
+      <div className="content-warpper">
+        <S.CategoryBody>{bodyContent}</S.CategoryBody>
+      </div>
       <S.Nav>{NavBar}</S.Nav>
     </S.CategoryContainer>
   );

--- a/fe/src/components/templates/CategoryTemplate/style.ts
+++ b/fe/src/components/templates/CategoryTemplate/style.ts
@@ -1,6 +1,19 @@
 import styled from 'styled-components';
 
-export const CategoryContainer = styled.div``;
+export const CategoryContainer = styled.div`
+  margin: 0 auto;
+  .content-warpper {
+    width: 100%;
+    @media only screen and (min-width: 768px) {
+      width: 700px;
+      margin: 0 auto;
+    }
+    @media only screen and (min-width: 1024px) {
+      width: 1000px;
+      margin: 0 auto;
+    }
+  }
+`;
 
 export const CategoryHeader = styled.div``;
 
@@ -11,7 +24,7 @@ export const CategoryTitle = styled.div`
 `;
 
 export const CategoryBody = styled.div`
-  height: calc(100vh - 7rem - 50px);
+  height: calc(100vh - 4rem - 50px);
 `;
 export const Nav = styled.nav`
   display: flex;

--- a/fe/src/components/templates/FormTransaction/index.tsx
+++ b/fe/src/components/templates/FormTransaction/index.tsx
@@ -10,7 +10,9 @@ const Template = ({ header, main }: Props): React.ReactElement => {
   return (
     <div>
       <S.Header>{header}</S.Header>
-      <S.Main>{main}</S.Main>
+      <S.Main>
+        <div className="content-warpper">{main}</div>
+      </S.Main>
     </div>
   );
 };

--- a/fe/src/components/templates/FormTransaction/style.ts
+++ b/fe/src/components/templates/FormTransaction/style.ts
@@ -9,7 +9,20 @@ export const Header = styled.header`
 
 export const Main = styled.main`
   margin-top: 3rem;
+  width: 100%;
   height: calc(100vh - 8rem);
   overflow-x: hidden;
   overflow-y: auto;
+  .content-warpper {
+    width: 100%;
+    margin: 0 auto;
+    @media only screen and (min-width: 768px) {
+      width: 700px;
+      margin: 0 auto;
+    }
+    @media only screen and (min-width: 1024px) {
+      width: 1000px;
+      margin: 0 auto;
+    }
+  }
 `;

--- a/fe/src/components/templates/MainTemplate/index.tsx
+++ b/fe/src/components/templates/MainTemplate/index.tsx
@@ -19,8 +19,10 @@ const MainTemplate = ({
     <S.Container {...props}>
       <S.Header>{HeaderBar}</S.Header>
       <S.ContentArea>
-        {SubHeaderBar}
-        <S.Content>{Contents}</S.Content>
+        <div className="content-wapper">
+          {SubHeaderBar}
+          <S.Content>{Contents}</S.Content>
+        </div>
       </S.ContentArea>
       {NavBar && <S.Nav>{NavBar}</S.Nav>}
     </S.Container>

--- a/fe/src/components/templates/MainTemplate/index.tsx
+++ b/fe/src/components/templates/MainTemplate/index.tsx
@@ -19,7 +19,7 @@ const MainTemplate = ({
     <S.Container {...props}>
       <S.Header>{HeaderBar}</S.Header>
       <S.ContentArea>
-        <div className="content-wapper">
+        <div className="content-warpper">
           {SubHeaderBar}
           <S.Content>{Contents}</S.Content>
         </div>

--- a/fe/src/components/templates/MainTemplate/style.ts
+++ b/fe/src/components/templates/MainTemplate/style.ts
@@ -1,7 +1,11 @@
 import styled from 'styled-components';
 import FilterBarComponent from 'components/organisms/FilterBar';
 
-export const Container = styled.div``;
+export const Container = styled.div`
+  .main-contaner {
+    width: 100%;
+  }
+`;
 
 export const FilterBar = styled(FilterBarComponent)`
   margin-top: 0.3rem;
@@ -15,8 +19,20 @@ export const ContentArea = styled.div`
   width: 100%;
   top: 3rem;
   height: calc(100vh - 3rem - 4rem - 2px);
-  left: 0;
   padding: 0.5em 1em;
+  left: 0;
+  .content-wapper {
+    width: 100%;
+    margin: 0 auto;
+    @media only screen and (min-width: 768px) {
+      width: 700px;
+      margin: 0 auto;
+    }
+    @media only screen and (min-width: 1024px) {
+      width: 1000px;
+      margin: 0 auto;
+    }
+  }
 `;
 
 export const Header = styled.header`

--- a/fe/src/components/templates/MainTemplate/style.ts
+++ b/fe/src/components/templates/MainTemplate/style.ts
@@ -21,7 +21,7 @@ export const ContentArea = styled.div`
   height: calc(100vh - 3rem - 4rem - 2px);
   padding: 0.5em 1em;
   left: 0;
-  .content-wapper {
+  .content-warpper {
     width: 100%;
     margin: 0 auto;
     @media only screen and (min-width: 768px) {

--- a/fe/src/pages/CategoryPage/index.tsx
+++ b/fe/src/pages/CategoryPage/index.tsx
@@ -220,7 +220,6 @@ function CategoryPage(): React.ReactElement {
   return (
     <CategoryTemplate
       headerContent={<Header />}
-      title="카테고리 설정"
       bodyContent={bodyContent}
       NavBar={<NavBarComponent />}
     />

--- a/fe/src/stores/Transaction/index.ts
+++ b/fe/src/stores/Transaction/index.ts
@@ -31,10 +31,7 @@ export interface ITransactionStore {
   modalDate: Date;
 }
 
-const oneMonthDate = date.getOneMonthRange(
-  String(new Date().getFullYear()),
-  String(new Date().getMonth() + 1),
-);
+const oneMonthDate = date.getOneMonthRange();
 
 const initialState: ITransactionStore = {
   transactions: {},

--- a/fe/src/styles/GlobalStyle.ts
+++ b/fe/src/styles/GlobalStyle.ts
@@ -20,6 +20,13 @@ const GlobalStyle = createGlobalStyle`
       font-family :  Bmeuljiro,sans-serif !important;
     }
     box-sizing: border-box;
+      font-size: 12px;
+    @media only screen and (min-width : 768px){
+      font-size: 14px;
+    }
+    @media only screen and (min-width : 1024px){
+      font-size: 16px;
+    }
   }
 
   menu, ol, ul {

--- a/fe/src/utils/date.ts
+++ b/fe/src/utils/date.ts
@@ -1,7 +1,10 @@
 import dayjs from 'dayjs';
 import 'dayjs/locale/ko';
+import utc from 'dayjs/plugin/utc';
 
+dayjs.extend(utc);
 dayjs.locale('ko');
+
 export default {
   dateFormatter: (date: Date): string => dayjs(date).format('YYYY-MM-DD'),
   dateCustomFormatter: (date: Date | string | number, format: string): string =>
@@ -10,16 +13,12 @@ export default {
     const nowMaxDate = new Date(date.getFullYear(), date.getMonth() + 1, -1);
     return nowMaxDate.getDate() + 1;
   },
-  getOneMonthRange: (year: string, month: string) => {
-    if (month === '12') {
-      return {
-        startDate: new Date(`${year}-${month}-1`),
-        endDate: new Date(`${Number(year) + 1}-${1}`),
-      };
-    }
+  getOneMonthRange: () => {
+    const now = dayjs().set('date', 1);
+    const endDate = now.add(1, 'month');
     return {
-      startDate: new Date(`${year}-${month}-1`),
-      endDate: new Date(`${year}-${Number(month) + 1}`),
+      startDate: now.toDate(),
+      endDate: endDate.toDate(),
     };
   },
   getNextDate: (date: Date | string) =>


### PR DESCRIPTION
## [변경사항](https://github.com/boostcamp-2020/Project16-A-Account-Book/pull/277/files/e8b39d8f6b9960d00455686583143e7f014587e4..235ba77b5974b85adfed1959ed1b88a2852c35b5)
<img width ='300px' src='https://user-images.githubusercontent.com/44409642/102416407-1c7bf300-403d-11eb-99fb-8509640155eb.png'/>
<img width='700px' src='https://user-images.githubusercontent.com/44409642/102416410-1e45b680-403d-11eb-90d2-21100e5ff5ab.png'/>

![f](https://user-images.githubusercontent.com/44409642/102416404-1be35c80-403d-11eb-86ad-76b9d5695052.png)

순서대로 스마트폰, 태블릿 , 데스크탑입니다. 

## 체크리스트
-   [x] 페이지별 breakPoint를 잡아서 값 조정
-  [x]  폰트 사이즈 조정
## Linked Issues
closes #276 

## 멘토님들

@boostcamp-2020/accountbook_mentor
