### PR TITLE
카테고리 중복 검사 로직 수정

### DIFF
--- a/be/src/controllers/category/index.ts
+++ b/be/src/controllers/category/index.ts
@@ -26,9 +26,9 @@ const put = async (ctx: Context) => {
   const { accountObjId } = ctx.params;
   const { objId, type, title, color } = ctx.request.body;
 
-  const res = await updateCategory(objId, type, title, color, accountObjId);
-  ctx.status = res.success ? 201 : 200;
-  ctx.body = res;
+  await updateCategory(objId, type, title, color, accountObjId);
+  ctx.status = 201;
+  ctx.res.end();
 };
 
 const deleteCategory = async (ctx: Context) => {

--- a/be/src/services/category/index.ts
+++ b/be/src/services/category/index.ts
@@ -16,6 +16,11 @@ export const getCategories = async (accountObjId: string) => {
 
   return categorisedType;
 };
+const isDuplicated = (existCategory: any, objid: string) => {
+  if (existCategory.categories.length === 0) return false;
+  if (String(existCategory.categories[0]._id) === objid) return false;
+  return true;
+};
 
 export const postCategory = async (
   type: string,
@@ -28,7 +33,7 @@ export const postCategory = async (
     type,
     title,
   );
-  if (exist.categories.length !== 0) throw duplicatedValue;
+  if (isDuplicated(exist, 'new')) throw duplicatedValue;
 
   const newCategory = new CategoryModel({
     type,
@@ -54,19 +59,9 @@ export const updateCategory = async (
     type,
     title,
   );
-  if (
-    (exist.categories[0] && String(exist.categories[0]._id) === objId) ||
-    exist.categories.length === 0
-  ) {
-    await CategoryModel.update(
-      { _id: objId },
-      { $set: { type, title, color } },
-    );
-    return {
-      success: true,
-    };
-  }
-  return { success: false, error: '중복되는 카테고리가 존재합니다' };
+  if (isDuplicated(exist, objId)) throw duplicatedValue;
+
+  return CategoryModel.update({ _id: objId }, { $set: { type, title, color } });
 };
 
 export const deleteOneCategory = async (

--- a/be/src/services/category/index.ts
+++ b/be/src/services/category/index.ts
@@ -16,7 +16,7 @@ export const getCategories = async (accountObjId: string) => {
 
   return categorisedType;
 };
-const isDuplicated = (existCategory: any, objid: string) => {
+const isDuplicated = (existCategory: any, objid?: string) => {
   if (existCategory.categories.length === 0) return false;
   if (String(existCategory.categories[0]._id) === objid) return false;
   return true;
@@ -33,7 +33,7 @@ export const postCategory = async (
     type,
     title,
   );
-  if (isDuplicated(exist, 'new')) throw duplicatedValue;
+  if (isDuplicated(exist)) throw duplicatedValue;
 
   const newCategory = new CategoryModel({
     type,

--- a/fe/src/pages/CategoryPage/index.tsx
+++ b/fe/src/pages/CategoryPage/index.tsx
@@ -8,6 +8,7 @@ import {
   categoryType,
   categoryConverter,
 } from 'stores/Category';
+import { ICategory } from 'types';
 import { TransactionStore } from 'stores/Transaction';
 import { MethodStore } from 'stores/Method';
 import Modal from 'components/molecules/Modal';
@@ -128,9 +129,11 @@ function CategoryPage(): React.ReactElement {
     if (exist && exist._id === selectedRef.current) {
       return Promise.resolve({ error: '변경사항이 없습니다!' });
     }
+
     if (exist) {
       return Promise.resolve({ error: '중복되는 입력입니다!' });
     }
+
     const body = {
       title: inputRef.current.value,
     };
@@ -139,20 +142,31 @@ function CategoryPage(): React.ReactElement {
       : methodAPI.createMethod;
     return func(TransactionStore.accountObjId, body, selectedRef.current);
   };
-  const categoryConfirm = async () => {
-    const exist = CategoryStore.getCategories(type).find(
-      (category) => category.title === inputRef.current.value.trim(),
-    );
+
+  const isMineAndCheckModify = (existCategory: ICategory | undefined) => {
     if (
-      exist &&
-      exist._id === selectedRef.current &&
-      exist.color === colorPicker.current.value
+      existCategory &&
+      existCategory._id === selectedRef.current &&
+      existCategory.color === colorPicker.current.value
     ) {
+      return true;
+    }
+    return false;
+  };
+  const isDuplicate = (existCategory: ICategory | undefined) =>
+    !!existCategory && existCategory._id !== selectedRef.current;
+  const categoryConfirm = async () => {
+    const newTitle = inputRef.current.value.trim();
+    const existCategory = CategoryStore.getCategories(type).find(
+      (category) => category.title === newTitle,
+    );
+    if (isMineAndCheckModify(existCategory)) {
       return Promise.resolve({ error: '변경사항이 없습니다!!' });
     }
-    if (exist && exist._id !== selectedRef.current) {
+    if (isDuplicate(existCategory)) {
       return Promise.resolve({ error: '중복된 타이틀이 존재합니다!' });
     }
+
     const body = {
       type,
       title: inputRef.current.value,


### PR DESCRIPTION
## 변경사항
### FE 
if에서 `&`연산으로 검사하는 부분을 따로 함수로 추출하였습니다. 
로컬에서 테스트 할 때는 정상적으로 동작하는 것을 확인하였습니다.
### BE
FE와 마찬가지로 검사하는 로직을 따로 함수로 추출하였습니다.
![screen-recording](https://user-images.githubusercontent.com/44409642/102451336-9cc14900-407b-11eb-86d8-a5f99070ae8e.gif)

## 멘토님들

@boostcamp-2020/accountbook_mentor
