### PR TITLE
모바일에서 Input 클릭 시 zoom-in되는 것 / Datepicker 모바일에서 사용하기 어려웠던 것 수정

### DIFF
--- a/fe/public/index.html
+++ b/fe/public/index.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="utf-8" />
     <link rel="icon" href="%PUBLIC_URL%/favicon.ico"/>
-    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=0" />
     <meta name="theme-color" content="#000000" />
   </head>
   <body>

--- a/fe/src/components/atoms/DatePicker/style.ts
+++ b/fe/src/components/atoms/DatePicker/style.ts
@@ -44,6 +44,7 @@ export const Container = styled.div`
     background-color: ${({ theme }) => theme.color.white};
     border: none;
     outline: none;
+    font-size: 0.8rem;
   }
   input {
     width: 4em;

--- a/fe/src/components/atoms/DatePicker/style.ts
+++ b/fe/src/components/atoms/DatePicker/style.ts
@@ -15,6 +15,31 @@ export const Container = styled.div`
   .react-datepicker__month-container {
     font-family: 'Bmeuljiro';
   }
+
+  @media only screen and (max-width: 768px) {
+    .react-datepicker__month-container {
+      height: 12.5rem;
+    }
+    .react-datepicker__week:not(:first-child) {
+      margin-top: 1em;
+    }
+    .react-datepicker__week {
+      height: 0.8em;
+    }
+    .react-datepicker__month {
+      margin-top: 0em;
+    }
+    .react-datepicker__day {
+      margin-top: 0.2em;
+    }
+    .react-datepicker__day-names {
+      margin-top: 0.2em;
+    }
+    .react-datepicker__day-name {
+      margin-top: 0.2em;
+    }
+  }
+
   .my-react-picker {
     background-color: ${({ theme }) => theme.color.white};
     border: none;

--- a/fe/src/components/atoms/Input/style.ts
+++ b/fe/src/components/atoms/Input/style.ts
@@ -9,6 +9,7 @@ const SInput = styled.input<Prop>`
   border: 1px solid;
   border-radius: 0.1rem;
   padding: 0.5% 1%;
+  font-size: 16px;
 
   background-color: ${({ disabled, theme }) =>
     disabled ? theme.color.gray : theme.color.white};

--- a/fe/src/components/organisms/TransactionInputField/style.ts
+++ b/fe/src/components/organisms/TransactionInputField/style.ts
@@ -13,6 +13,7 @@ export const Input = styled(InputAtom)`
 export const ButtonInput = styled(InputAtom)<ButtonInputProps>`
   width: 25%;
   height: 2rem;
+  font-size: 1rem;
   border: 1px solid
     ${({ active, theme }) => (active ? theme.color.blue : theme.color.subText)};
   color: ${({ active, theme }) =>

--- a/fe/src/styles/GlobalStyle.ts
+++ b/fe/src/styles/GlobalStyle.ts
@@ -20,7 +20,7 @@ const GlobalStyle = createGlobalStyle`
       font-family :  Bmeuljiro,sans-serif !important;
     }
     box-sizing: border-box;
-      font-size: 12px;
+    font-size: 12px;
     @media only screen and (min-width : 768px){
       font-size: 14px;
     }
@@ -50,6 +50,8 @@ const GlobalStyle = createGlobalStyle`
   a:active {
     color: black;
   }
+
+
 
 `;
 

--- a/fe/src/styles/GlobalStyle.ts
+++ b/fe/src/styles/GlobalStyle.ts
@@ -50,9 +50,6 @@ const GlobalStyle = createGlobalStyle`
   a:active {
     color: black;
   }
-
-
-
 `;
 
 export default GlobalStyle;


### PR DESCRIPTION
## 변경사항
![image](https://user-images.githubusercontent.com/34783156/102451775-849df980-407c-11eb-9a64-6fd03d92a773.png)

Input에 들어가는 텍스트 크기가 16px미만이면 IOS에서 자동으로 zoom-in을 해서 Input에 들어가는 텍스트 크기는 16px로 고정했습니다.
datePicker가 모바일에서 사용하기 어려웠었는데 CSS로 빈 공백 최대한 줄여서  사용하기 편하게 했습니다.

## 체크리스트
-   [x] Input관련 클릭했을 때 확대 안되게 잘 되는지
## Linked Issues
closes #285 
closes #289 

## 멘토님들

@boostcamp-2020/accountbook_mentor
