### PR TITLE
세션 스토리지에 가계부 정보 저장

### DIFF
--- a/fe/src/hooks/useAccountInfo.ts
+++ b/fe/src/hooks/useAccountInfo.ts
@@ -3,24 +3,84 @@ import accountsAPI from 'apis/account';
 import { TransactionStore } from 'stores/Transaction';
 import { useLocation, useHistory } from 'react-router-dom';
 
+interface IParsedAccountInfo {
+  id: string;
+  title: string;
+  owner: string;
+}
 const useAccountInfo = () => {
   const accountObjId = TransactionStore.getAccountId();
   const location = useLocation();
   const history = useHistory();
   const [loading, setLoading] = useState<boolean>(accountObjId === '');
-  const getAccountInfo = async () => {
+
+  const setAccountId = (id: string) => {
+    TransactionStore.setAccountObjId(id);
+    setLoading(false);
+  };
+  const getAccountInfoRe = async (owner: string, title: string) => {
+    const res = await accountsAPI.getAccountInfo(owner, title);
+    setAccountId(res._id);
+    const accountInfo = {
+      owner,
+      title,
+      id: res._id,
+    };
+    sessionStorage.setItem('account', JSON.stringify(accountInfo));
+  };
+
+  const parseAccountFromSession = (): IParsedAccountInfo | undefined => {
+    const accountInfoFromSession = sessionStorage.getItem('account');
+    if (!accountInfoFromSession) return undefined;
+    return JSON.parse(accountInfoFromSession);
+  };
+
+  const getOwnerAndTitleFromUrl = () => {
     const reg = /(\/transactions\/)(([^/])*)?\/(([^/])*)?/;
     const result = reg.exec(location.pathname);
     const owner = result ? result[2] : null;
     const title = result ? result[4] : null;
-    if (!owner || !title) {
+    return {
+      owner,
+      title,
+    };
+  };
+
+  const isVaildParsedAccountInfo = (
+    parseAccountInfo: IParsedAccountInfo | undefined,
+  ) => {
+    if (
+      !parseAccountInfo ||
+      !parseAccountInfo.owner ||
+      !parseAccountInfo.title ||
+      !parseAccountInfo.id
+    )
+      return false;
+    return true;
+  };
+
+  const isSameOwnerAndTitle = (
+    parseURL: any,
+    parseSession: IParsedAccountInfo,
+  ): boolean =>
+    parseURL.owner === parseSession.owner &&
+    parseURL.title === parseSession.title;
+
+  const getAccountInfo = async () => {
+    const parseAccountInfo = parseAccountFromSession();
+    const parseURL = getOwnerAndTitleFromUrl();
+    if (!parseURL.owner || !parseURL.title) {
+      sessionStorage.removeItem('account');
       history.push('/accounts');
       return;
     }
-
-    const res = await accountsAPI.getAccountInfo(owner, title);
-    TransactionStore.setAccountObjId(res._id);
-    setLoading(false);
+    if (!isVaildParsedAccountInfo(parseAccountInfo)) {
+      getAccountInfoRe(parseURL.owner, parseURL.title);
+      return;
+    }
+    if (isSameOwnerAndTitle(parseURL, parseAccountInfo as IParsedAccountInfo)) {
+      setAccountId(parseAccountInfo!.id);
+    }
   };
   useEffect(() => {
     if (loading) {

--- a/fe/src/pages/AccountListPage/index.tsx
+++ b/fe/src/pages/AccountListPage/index.tsx
@@ -8,8 +8,25 @@ import Account from 'components/organisms/Account';
 import { useHistory } from 'react-router-dom';
 import AccountSvg from 'assets/svg/account.svg';
 import userApi from 'apis/user';
-
 import * as S from './styles';
+
+const setSessionByAccountIno = (
+  accountObjId: string,
+  accountTitle: string,
+  accountOwner: string,
+) => {
+  const accountInfo = {
+    title: accountTitle,
+    owner: accountOwner,
+    id: accountObjId,
+  };
+  sessionStorage.setItem('account', JSON.stringify(accountInfo));
+};
+
+const setTransactionStorageInfo = (accountObjId: string) => {
+  TransactionStore.resetFilter();
+  TransactionStore.setAccountObjId(accountObjId);
+};
 
 const onClickHandler = (
   history: any,
@@ -17,13 +34,9 @@ const onClickHandler = (
   accountTitle: string,
   accountOwner: string,
 ) => () => {
-  sessionStorage.setItem(
-    'account',
-    JSON.stringify({ id: accountObjId, title: accountTitle }),
-  );
+  setSessionByAccountIno(accountObjId, accountTitle, accountTitle);
   sessionStorage.removeItem('filter');
-  TransactionStore.resetFilter();
-  TransactionStore.setAccountObjId(accountObjId);
+  setTransactionStorageInfo(accountObjId);
   history.push(`/transactions/${accountOwner}/${accountTitle}`);
 };
 


### PR DESCRIPTION
## 변경사항
세션 스토리지에 가계부의 `id, title, owner`를 저장하여 새로고침 했을 때 새로 요청을 안보내도록 하기 위한 작업을 하였습니다. 

## 체크리스트
- [x] 가계부 리스트 페이지에서 session 저장 하기
- [x] useAccountInfo 에서 세션 분석해서 있으면 재사용하는 로직 생성

## 멘토님들

@boostcamp-2020/accountbook_mentor
