### PR TITLE
거래내역 폼에서 최대값이 1조 미만 & 거래내역 폼 에러 메시지 수정

### DIFF
--- a/be/src/libs/error.ts
+++ b/be/src/libs/error.ts
@@ -63,7 +63,7 @@ export const duplicatedValue = {
 
 export const invalidPrice = {
   status: 200,
-  error: '가격에 음수가 올 수 없습니다.',
+  error: '가격은 0이상 1조 미만이어야 합니다.',
   success: false,
 };
 export const invalidForm = {

--- a/be/src/middlewares/index.ts
+++ b/be/src/middlewares/index.ts
@@ -113,6 +113,8 @@ export const isDuplicateAccountTitle = async (
   const findDuplicate = await AccountModel.find({ title });
   if (findDuplicate.length !== 0) {
     throw duplicatedValue;
+  }
+};
 export const isValidPrice = async (
   ctx: Koa.Context,
   next: () => Promise<any>,

--- a/be/src/middlewares/index.ts
+++ b/be/src/middlewares/index.ts
@@ -119,13 +119,14 @@ export const isValidPrice = async (
   ctx: Koa.Context,
   next: () => Promise<any>,
 ) => {
+  const TRILLION = 10 ** 12;
   const {
     transaction: { price },
   } = ctx.request.body;
   if (!price) {
     throw invalidForm;
   }
-  if (price < 0) {
+  if (price < 0 || price >= TRILLION) {
     throw invalidPrice;
   }
   await next();

--- a/fe/src/components/atoms/Input/index.tsx
+++ b/fe/src/components/atoms/Input/index.tsx
@@ -12,6 +12,7 @@ export interface Props {
   type?: string;
   inputRef?: any;
   onKeyDown?: any;
+  className?: string;
 }
 
 const Input = ({
@@ -24,6 +25,7 @@ const Input = ({
   name,
   id,
   inputRef,
+  className,
   ...props
 }: Props): React.ReactElement => {
   return (
@@ -37,6 +39,7 @@ const Input = ({
       value={value}
       disabled={disabled}
       ref={inputRef}
+      className={className}
       {...props}
     />
   );

--- a/fe/src/components/atoms/Message/index.stories.tsx
+++ b/fe/src/components/atoms/Message/index.stories.tsx
@@ -1,0 +1,18 @@
+import React from 'react';
+import { withKnobs, select } from '@storybook/addon-knobs';
+import GlobalThemeProvider from 'styles/GlobalThemeProvider';
+import Message from '.';
+
+export default {
+  title: 'atoms/Message',
+  component: Message,
+  decorators: [withKnobs],
+};
+export const priceTag = () => {
+  const tag = select('tag', ['error', 'warning', 'info', 'success'], 'error');
+  return (
+    <GlobalThemeProvider>
+      <Message tag={tag}>message입니다!</Message>
+    </GlobalThemeProvider>
+  );
+};

--- a/fe/src/components/atoms/Message/index.tsx
+++ b/fe/src/components/atoms/Message/index.tsx
@@ -1,0 +1,17 @@
+import React from 'react';
+import * as S from './style';
+
+export interface Props {
+  children: React.ReactElement | React.ReactElement[] | string;
+  tag?: 'error' | 'warning' | 'info' | 'success';
+  size?: 'xs' | 'sm' | 'md' | 'lg' | 'xl';
+}
+const Message = ({ children, tag = 'error', size = 'md' }: Props) => {
+  return (
+    <S.Message tag={tag} size={size}>
+      {children}
+    </S.Message>
+  );
+};
+
+export default Message;

--- a/fe/src/components/atoms/Message/style.ts
+++ b/fe/src/components/atoms/Message/style.ts
@@ -1,0 +1,10 @@
+import styled from 'styled-components';
+
+export interface Props {
+  tag: 'error' | 'warning' | 'info' | 'success';
+  size: 'xs' | 'sm' | 'md' | 'lg' | 'xl';
+}
+export const Message = styled.span<Props>`
+  color: ${({ tag, theme }) => theme.tag[tag]};
+  font-size: ${({ size, theme }) => theme.fontSize[size]};
+`;

--- a/fe/src/components/organisms/TransactionInputField/index.stories.tsx
+++ b/fe/src/components/organisms/TransactionInputField/index.stories.tsx
@@ -44,3 +44,42 @@ export const Transaction = () => {
     </ThemeProvider>
   );
 };
+export const InvalidForm = () => {
+  const classifications = ['지출', '수입'];
+
+  const [formValue, setFormValue] = useState({
+    category: '',
+    date: dayjs(new Date()).format('YYYY-MM-DD'),
+    client: '',
+    memo: '',
+    classification: '',
+    method: '',
+    price: 0,
+  });
+
+  const formHandler = ({ target }: any): void => {
+    const { name, value } = target;
+    setFormValue((prevformValue) => ({ ...prevformValue, [name]: value }));
+  };
+  const message = {
+    price: '잘못된 가격입니다.',
+    client: '거래처를 입력해주세요',
+  };
+
+  return (
+    <ThemeProvider theme={theme}>
+      <TransactionInputField
+        price={formValue.price}
+        date={formValue.date}
+        classification={formValue.classification}
+        classifications={classifications}
+        client={formValue.client}
+        memo={formValue.memo}
+        formHandler={formHandler}
+        method={formValue.method}
+        category={formValue.category}
+        message={message}
+      />
+    </ThemeProvider>
+  );
+};

--- a/fe/src/components/organisms/TransactionInputField/index.tsx
+++ b/fe/src/components/organisms/TransactionInputField/index.tsx
@@ -48,14 +48,14 @@ const TransactionInputField = ({
   const methods = MethodStore.getMethods();
   const categories = CategoryStore.getCategories(classification);
   const newPrice = price === 0 ? undefined : price;
-  const PriceMessage = message?.price && (
+  const PriceMessage = message?.price !== '' && (
     <Message tag="error" size="sm">
-      {message.price}
+      {message?.price || ''}
     </Message>
   );
-  const ClientMessage = message?.client && (
+  const ClientMessage = message?.client !== '' && (
     <Message tag="error" size="sm">
-      {message.client}
+      {message?.client || ''}
     </Message>
   );
   return (
@@ -69,7 +69,7 @@ const TransactionInputField = ({
             placeholder="금액을 입력하세요"
             onChangeHandler={formHandler}
             type="number"
-            className={message?.price ? 'invalid' : ''}
+            className={message?.price !== '' ? 'invalid' : ''}
           />
         </>
       </LabelWrap>
@@ -107,7 +107,7 @@ const TransactionInputField = ({
             value={client}
             placeholder="거래처명을 입력하세요"
             onChangeHandler={formHandler}
-            className={message?.client ? 'invalid' : ''}
+            className={message?.client !== '' ? 'invalid' : ''}
           />
         </>
       </LabelWrap>

--- a/fe/src/components/organisms/TransactionInputField/index.tsx
+++ b/fe/src/components/organisms/TransactionInputField/index.tsx
@@ -6,6 +6,7 @@ import { MethodStore } from 'stores/Method';
 import { CategoryStore } from 'stores/Category';
 import { observer } from 'mobx-react-lite';
 import DatePicker from 'components/atoms/DatePicker';
+import Message from 'components/atoms/Message';
 import * as S from './style';
 
 const CLASSIFICATION = 'classification';
@@ -26,6 +27,10 @@ export interface Props {
   category: string;
   method: string;
   formHandler: any;
+  message?: {
+    price?: string;
+    client?: string;
+  };
 }
 
 const TransactionInputField = ({
@@ -38,20 +43,35 @@ const TransactionInputField = ({
   price,
   category,
   method,
+  message,
 }: Props): React.ReactElement => {
   const methods = MethodStore.getMethods();
   const categories = CategoryStore.getCategories(classification);
   const newPrice = price === 0 ? undefined : price;
+  const PriceMessage = message?.price && (
+    <Message tag="error" size="sm">
+      {message.price}
+    </Message>
+  );
+  const ClientMessage = message?.client && (
+    <Message tag="error" size="sm">
+      {message.client}
+    </Message>
+  );
   return (
     <S.Container>
       <LabelWrap htmlFor={PRICE} title="금액">
-        <S.Input
-          value={newPrice}
-          name={PRICE}
-          placeholder="금액을 입력하세요"
-          onChangeHandler={formHandler}
-          type="number"
-        />
+        <>
+          {PriceMessage}
+          <S.Input
+            value={newPrice}
+            name={PRICE}
+            placeholder="금액을 입력하세요"
+            onChangeHandler={formHandler}
+            type="number"
+            className={message?.price ? 'invalid' : ''}
+          />
+        </>
       </LabelWrap>
       <LabelWrap htmlFor={CLASSIFICATION} title="분류">
         {classifications.map((classItem) => (
@@ -80,12 +100,16 @@ const TransactionInputField = ({
         </select>
       </LabelWrap>
       <LabelWrap htmlFor={CLIENT} title="거래처">
-        <S.Input
-          name={CLIENT}
-          value={client}
-          placeholder="거래처명을 입력하세요"
-          onChangeHandler={formHandler}
-        />
+        <>
+          {ClientMessage}
+          <S.Input
+            name={CLIENT}
+            value={client}
+            placeholder="거래처명을 입력하세요"
+            onChangeHandler={formHandler}
+            className={message?.client ? 'invalid' : ''}
+          />
+        </>
       </LabelWrap>
       <LabelWrap htmlFor={METHOD} title="결제수단">
         <select name={METHOD} id={METHOD} onChange={formHandler}>

--- a/fe/src/components/organisms/TransactionInputField/style.ts
+++ b/fe/src/components/organisms/TransactionInputField/style.ts
@@ -8,6 +8,9 @@ export interface ButtonInputProps extends InputProps {
 export const Input = styled(InputAtom)`
   height: 2rem;
   border: transparent;
+  &.invalid {
+    border: 1px solid ${({ theme }) => theme.tag.error};
+  }
 `;
 
 export const ButtonInput = styled(InputAtom)<ButtonInputProps>`

--- a/fe/src/pages/CreateTransactionPage/index.tsx
+++ b/fe/src/pages/CreateTransactionPage/index.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useState } from 'react';
 import FormTransactionTemplate from 'components/templates/FormTransaction';
 import TransactionForm from 'components/organisms/TransactionForm';
 import useTransactionInput from 'hooks/useTransactionInput';
@@ -14,18 +14,15 @@ const classifications = ['지출', '수입'];
 const CreateTransacionPage = () => {
   const [transactionState, setInputState] = useTransactionInput();
   const history = useHistory();
-
-  const inputFieldProps = {
-    ...transactionState,
-    classifications,
-    formHandler: setInputState,
-  };
+  const [message, setMessage] = useState({
+    client: '',
+    price: '',
+  });
 
   const onSubmitHandler = async () => {
-    const flag = transactionValidator(transactionState);
-
-    if (!flag) {
-      alert('🙀입력을 확인하세요!🙀 ');
+    const [isValid, errorMessage] = transactionValidator(transactionState);
+    if (!isValid) {
+      setMessage(errorMessage);
       return;
     }
     await transactionAPI.saveTransaction(
@@ -34,6 +31,14 @@ const CreateTransacionPage = () => {
     );
     history.goBack();
   };
+
+  const inputFieldProps = {
+    ...transactionState,
+    classifications,
+    formHandler: setInputState,
+    message,
+  };
+
   const Main = (
     <TransactionForm
       InputFieldProps={inputFieldProps}

--- a/fe/src/pages/UpdateTransactionPage/index.tsx
+++ b/fe/src/pages/UpdateTransactionPage/index.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useState } from 'react';
 import FormTransactionTemplate from 'components/templates/FormTransaction';
 import TransactionForm from 'components/organisms/TransactionForm';
 import useTransactionInput from 'hooks/useTransactionInput';
@@ -13,21 +13,19 @@ const classifications = ['지출', '수입'];
 
 const UpdateTransacionPage = ({ location }: { location: any }) => {
   const { transactionObjId } = queryString.parse(location.search);
+  const [message, setMessage] = useState({
+    client: '',
+    price: '',
+  });
   const [transactionState, setInputState] = useTransactionInput(
     transactionObjId as string,
   );
   const history = useHistory();
-  const inputFieldProps = {
-    ...transactionState,
-    classifications,
-    formHandler: setInputState,
-  };
 
   const onSubmitHandler = async () => {
-    const flag = transactionValidator(transactionState);
-
-    if (!flag) {
-      alert('🙀입력을 확인하세요!🙀');
+    const [isValid, errorMessage] = transactionValidator(transactionState);
+    if (!isValid) {
+      setMessage(errorMessage);
       return;
     }
     await transactionAPI.updateTransaction(
@@ -45,6 +43,12 @@ const UpdateTransacionPage = ({ location }: { location: any }) => {
       transactionObjId as string,
     );
     history.goBack();
+  };
+  const inputFieldProps = {
+    ...transactionState,
+    classifications,
+    formHandler: setInputState,
+    message,
   };
   const Main = (
     <TransactionForm

--- a/fe/src/styles/theme.ts
+++ b/fe/src/styles/theme.ts
@@ -32,10 +32,17 @@ const color = {
   red: '#fa5252',
 };
 
+const tag = {
+  error: '#fa5252',
+  warning: '#EC8A13',
+  info: '#41BE69',
+  success: '#1F80E0',
+};
 const theme = {
   fontSize,
   color,
   len,
+  tag,
 };
 
 export default theme;

--- a/fe/src/utils/validator.ts
+++ b/fe/src/utils/validator.ts
@@ -8,8 +8,13 @@ const isBlank = (value: any) => {
   );
 };
 
-const checkAllRequiredInputFilled = (form: State) => {
-  return Object.entries(form).every(([key, value]) => {
+interface Message {
+  client: string;
+  price: string;
+}
+const checkAllRequiredInputFilled = (form: State): [boolean, Message] => {
+  const message = { client: '', price: '' };
+  const isAllFilled = Object.entries(form).every(([key, value]) => {
     if (key !== 'memo' && key !== 'classification') {
       if (isBlank(value)) {
         return false;
@@ -17,17 +22,37 @@ const checkAllRequiredInputFilled = (form: State) => {
     }
     return true;
   });
+  if (isBlank(form.client)) {
+    message.client = '거래처를 입력해주세요';
+  }
+  if (isBlank(form.price)) {
+    message.price = '가격을 입력해주세요';
+  }
+  return [isAllFilled, message];
 };
 
-const isMoneyInRange = (money: number) => {
+const isMoneyInRange = (money: number): [boolean, Message] => {
   const TRILLION = 10 ** 12;
-  return money >= 0 && money < TRILLION;
+  const isValidMoney = money >= 0 && money < TRILLION;
+  if (!isValidMoney) {
+    return [
+      false,
+      { price: '가격은 0이상 1조 미만의 값이 입력되어야 합니다.', client: '' },
+    ];
+  }
+  return [true, { price: '', client: '' }];
 };
 
-export const transactionValidator = (form: State) => {
-  const isValid =
-    checkAllRequiredInputFilled(form) && isMoneyInRange(form.price);
-  return isValid;
+export const transactionValidator = (form: State): [boolean, Message] => {
+  const [isAllFilled, fieldMessage] = checkAllRequiredInputFilled(form);
+  if (!isAllFilled) {
+    return [false, fieldMessage];
+  }
+  const [isValid, moneyMessage] = isMoneyInRange(form.price);
+  if (!isValid) {
+    return [false, moneyMessage];
+  }
+  return [true, { price: '', client: '' }];
 };
 
 export default {};

--- a/fe/src/utils/validator.ts
+++ b/fe/src/utils/validator.ts
@@ -19,10 +19,14 @@ const checkAllRequiredInputFilled = (form: State) => {
   });
 };
 
-const isPositive = (num: number) => num >= 0;
+const isMoneyInRange = (money: number) => {
+  const TRILLION = 10 ** 12;
+  return money >= 0 && money < TRILLION;
+};
 
 export const transactionValidator = (form: State) => {
-  const isValid = checkAllRequiredInputFilled(form) && isPositive(form.price);
+  const isValid =
+    checkAllRequiredInputFilled(form) && isMoneyInRange(form.price);
   return isValid;
 };
 


### PR DESCRIPTION
## 변경사항
- 거래내역의 에러가 생기면, 해당 폼에서 에러를 알려줄 수 있도록 하였습니다.
<img width="364" alt="스크린샷 2020-12-17 오후 4 54 24" src="https://user-images.githubusercontent.com/43772082/102459273-bd43d000-4088-11eb-98d8-505ed237e866.png">

<img width="383" alt="스크린샷 2020-12-17 오후 4 54 10" src="https://user-images.githubusercontent.com/43772082/102459278-bf0d9380-4088-11eb-93dd-c716c72c3bba.png">

- 에러 메시지는 Message 컴포넌트를 만들어서 띄워주었습니다.

![2020-12-17 16 58 12](https://user-images.githubusercontent.com/43772082/102459559-1c094980-4089-11eb-9100-782b7a84419e.gif)






## 체크리스트
- [ ] 가격은 0원 이사 1조 미만만 입력할 수 있다.
- [ ] 거래내역 입력시 에러를 확인할 수 있다.
## Linked Issues
closes #293 
closes #291

## 멘토님들

@boostcamp-2020/accountbook_mentor
