### PR TITLE
가계부 생성/수정 페이지 중복 검사 로직 수정 

### DIFF
--- a/be/src/services/account/index.ts
+++ b/be/src/services/account/index.ts
@@ -52,10 +52,7 @@ export const createNewAccount = async (
     CategoryModel.createDefaultCategory(),
     MethodModel.createDefaultMethod(),
   ]);
-  const findDuplicate = await AccountModel.find({ title });
-  if (findDuplicate.length !== 0) {
-    throw duplicatedValue;
-  }
+
   const newAccount = new AccountModel({
     title,
     ownerName: user.nickname,
@@ -78,10 +75,6 @@ export const updateAccountByUserAndAccountInfo = async (
   userObjIdList: string[],
   user: IUserDocument,
 ) => {
-  const findDuplicate = await AccountModel.find({ title });
-  if (findDuplicate.length !== 0) {
-    throw duplicatedValue;
-  }
   const updateAccount = AccountModel.updateOne(
     { _id: accountObjId },
     {

--- a/fe/src/pages/AccountUpdatePage/index.tsx
+++ b/fe/src/pages/AccountUpdatePage/index.tsx
@@ -83,24 +83,30 @@ const AccountUpdatePage = ({ location }: Props) => {
     const title = titleInputRef.current.value;
 
     const verifyResult = accountTitleVerify(title, account.title);
+
     if (verifyResult !== '') {
       setTitleErrorMessage(verifyResult);
       return;
     }
     let serverMessage = '';
     if (isNewAccount) {
-      const result = await accountAPI.createAccount(title, checkedUserIdList);
-      if (result.data && 'error' in result.data) {
-        serverMessage = result.data.error;
+      const result: any = await accountAPI.createAccount(
+        title,
+        checkedUserIdList,
+      );
+
+      if (result.error) {
+        serverMessage = result.error;
       }
     } else {
-      const result = await accountAPI.updateAccount(
+      const result: any = await accountAPI.updateAccount(
         account._id,
         title,
         checkedUserIdList,
       );
-      if (result.data && 'error' in result.data) {
-        serverMessage = result.data.error;
+
+      if (result.error) {
+        serverMessage = result.error;
       }
     }
     if (serverMessage !== '') {


### PR DESCRIPTION
## 변경사항
### FE 
반환 값을 받는 부분이 axios로 인해서 res.data를 미리 리턴했기 때문에 res.error 로 접근 해야 반한된 에러 메세지 접근 할 수 있도록 수정 하였습니다.

### BE  
타이틀검사 미들웨어에서 수정 하고자하는 메소드일때 자기자신이면 통과하도록 미들웨어 수정

## 멘토님들

@boostcamp-2020/accountbook_mentor
