### PR TITLE
거래처에서 이름 길어졌을 때, ...으로 처리

### DIFF
--- a/be/src/middlewares/index.ts
+++ b/be/src/middlewares/index.ts
@@ -113,6 +113,8 @@ export const isDuplicateAccountTitle = async (
   const findDuplicate = await AccountModel.find({ title });
   if (findDuplicate.length !== 0) {
     throw duplicatedValue;
+  }
+};
 export const isValidPrice = async (
   ctx: Koa.Context,
   next: () => Promise<any>,

--- a/fe/src/components/molecules/Transaction/index.tsx
+++ b/fe/src/components/molecules/Transaction/index.tsx
@@ -1,6 +1,8 @@
 import React from 'react';
 import doubleArrowIcon from 'assets/svg/doubleArrow.svg';
 import PriceWithSign from 'components/molecules/PriceWithSign';
+import Icon from 'components/atoms/Icons';
+
 import * as S from './style';
 
 export interface Props {
@@ -14,13 +16,15 @@ const Transaction = ({ trans, onClick }: Props) => {
 
   return (
     <S.TransactionStyle onClick={() => onClick(trans.id)}>
-      <S.TransactionIcon icon={trans.icon || doubleArrowIcon} size="sm" />
+      <Icon icon={trans.icon || doubleArrowIcon} size="sm" />
       <S.Text>
         <S.PaymentInfo>
           <S.Client>{trans.client}</S.Client>
           <S.Classification>{classificationString}</S.Classification>
         </S.PaymentInfo>
-        <PriceWithSign price={trans.price} type={type} />
+        <S.PriceWrap>
+          <PriceWithSign price={trans.price} type={type} />
+        </S.PriceWrap>
       </S.Text>
     </S.TransactionStyle>
   );

--- a/fe/src/components/molecules/Transaction/style.ts
+++ b/fe/src/components/molecules/Transaction/style.ts
@@ -1,5 +1,4 @@
 import styled from 'styled-components';
-import Icon from 'components/atoms/Icons';
 
 export const TransactionStyle = styled.div`
   box-sizing: border-box;
@@ -20,12 +19,29 @@ export const Text = styled.div`
 `;
 
 export const PaymentInfo = styled.div`
+  display: flex;
+  flex: 6 1 auto;
   margin-left: 0.5em;
+  flex-direction: column;
+  @media only screen and (min-width: 300px) {
+    width: 12em;
+  }
+  @media only screen and (min-width: 1024px) {
+    width: 20em;
+  }
 `;
 
-export const TransactionIcon = styled(Icon)``;
+export const PriceWrap = styled.div`
+  display: flex;
+  flex: 4 1 auto;
+  justify-content: flex-end;
+`;
 
-export const Client = styled.div``;
+export const Client = styled.div`
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+`;
 
 export const Classification = styled.div`
   font-size: 0.7rem;


### PR DESCRIPTION
## 변경사항
- 모바일 환경
<img width="369" alt="스크린샷 2020-12-17 오후 6 04 02" src="https://user-images.githubusercontent.com/43772082/102466687-b326cf00-4092-11eb-9a54-816d646bbf72.png">

- 데스크탑 환경
<img width="1058" alt="스크린샷 2020-12-17 오후 6 04 16" src="https://user-images.githubusercontent.com/43772082/102466684-b15d0b80-4092-11eb-8052-8345c3c3576b.png">

## 체크리스트
- [ ] 거래내역이 길어지면 ...으로 처리한다.
## Linked Issues
closes #309
## 멘토님들

@boostcamp-2020/accountbook_mentor
