### PR TITLE
IOS에서 버튼 모양 다른 것 수정

### DIFF
--- a/fe/src/styles/GlobalStyle.ts
+++ b/fe/src/styles/GlobalStyle.ts
@@ -28,12 +28,7 @@ const GlobalStyle = createGlobalStyle`
       font-size: 16px;
     }
   }
-  button {
-    -moz-appearance: none; /* Firefox */
-    -webkit-appearance: none; /* Safari and Chrome */
-    appearance: none;
-  }
-  input {
+  button, input {
     -moz-appearance: none; /* Firefox */
     -webkit-appearance: none; /* Safari and Chrome */
     appearance: none;

--- a/fe/src/styles/GlobalStyle.ts
+++ b/fe/src/styles/GlobalStyle.ts
@@ -28,6 +28,16 @@ const GlobalStyle = createGlobalStyle`
       font-size: 16px;
     }
   }
+  button {
+    -moz-appearance: none; /* Firefox */
+    -webkit-appearance: none; /* Safari and Chrome */
+    appearance: none;
+  }
+  input {
+    -moz-appearance: none; /* Firefox */
+    -webkit-appearance: none; /* Safari and Chrome */
+    appearance: none;
+  }
 
   menu, ol, ul {
     list-style: none;


### PR DESCRIPTION
## 변경사항
![image](https://user-images.githubusercontent.com/34783156/102472701-e751be00-4099-11eb-8dc6-27bdc2aada23.png)

IOS에선 기본 스타일을 강제하는데 그것 푸는 CSS코드를 추가했습니다.
## 체크리스트
-   [x] 모양 데스크탑 버전이랑 비슷하게 보이는지

## Linked Issues
closes #290 

## 멘토님들

@boostcamp-2020/accountbook_mentor
