### PR TITLE
[FE] Style : 카테고리 호버 색 추가

### DIFF
--- a/fe/src/components/molecules/CategoryDropdown/style.ts
+++ b/fe/src/components/molecules/CategoryDropdown/style.ts
@@ -4,9 +4,13 @@ import EditButton from 'components/atoms/EditButton';
 export const CheckBoxContainer = styled.div`
   margin-left: auto;
 `;
+
 export const DropdownItem = styled.div`
   border: none;
   padding: 0.5rem;
+  &:hover {
+    background: ${({ theme }) => theme.color.transparentBrandColor};
+  }
   & + & {
     border-top: 1px solid ${({ theme }) => theme.color.subText};
   }


### PR DESCRIPTION
## 변경사항
![image](https://user-images.githubusercontent.com/44409642/102486744-d8c0d200-40ac-11eb-9269-fbe147764edc.png)

메인 화면 처럼 마우스 올리면 색이 나오도록 하였습니다. 

## 멘토님들

@boostcamp-2020/accountbook_mentor
