### PR TITLE
기간 해당하는 달력 모두 보여주기 / 달력 한칸 보이는 돈 요약해서 보여주도록 수정

### DIFF
--- a/fe/src/components/molecules/CalendarOneDate/index.tsx
+++ b/fe/src/components/molecules/CalendarOneDate/index.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import utils from 'utils';
 import * as S from './style';
 
 export interface OneDateType {
@@ -23,10 +24,14 @@ const CalendarOneDate = ({
     <S.CalendarOneDate onClick={(income || expense) && onClick} {...props}>
       <S.DateText>{date}</S.DateText>
       <S.PriceTextWrap>
-        <S.IncomeText>{income && `${income}`}</S.IncomeText>
-        <S.ExpenseText>{expense && `${expense}`}</S.ExpenseText>
+        <S.IncomeText>
+          {income && `${utils.summaryOfMoney(income)}원`}
+        </S.IncomeText>
+        <S.ExpenseText>
+          {expense && `${utils.summaryOfMoney(expense)}원`}
+        </S.ExpenseText>
         <S.UnclassifiedText>
-          {unclassified && `${unclassified}`}
+          {unclassified && `${utils.summaryOfMoney(unclassified)}원`}
         </S.UnclassifiedText>
       </S.PriceTextWrap>
       <S.EmptyArea />

--- a/fe/src/components/molecules/CalendarOneDate/style.ts
+++ b/fe/src/components/molecules/CalendarOneDate/style.ts
@@ -5,7 +5,7 @@ export const CalendarOneDate = styled(Button)`
   background-color: ${({ theme }) => theme.color.white};
   border: none;
   width: 14.5%;
-  height: 5rem;
+  height: 4.2rem;
   text-align: left;
   background-color: transparent;
 
@@ -20,28 +20,28 @@ export const DateText = styled.div`
   height: 20%;
 `;
 
+export const EmptyArea = styled.div`
+  height: 30%;
+`;
+
 export const PriceTextWrap = styled.div`
-  margin-top: 2em;
+  margin-top: 0.4em;
   font-size: 0.75rem;
   height: 50%;
   text-align: right;
 `;
 
-export const EmptyArea = styled.div`
-  height: 30%;
-`;
-
 export const IncomeText = styled.div`
-  font-size: 0.4rem;
+  font-size: 0.8rem;
   color: ${({ theme }) => theme.color.brandColor};
 `;
 
 export const ExpenseText = styled.div`
-  font-size: 0.4rem;
+  font-size: 0.8rem;
   color: ${({ theme }) => theme.color.red};
 `;
 
 export const UnclassifiedText = styled.div`
-  font-size: 0.4rem;
+  font-size: 0.8rem;
   color: ${({ theme }) => theme.color.black};
 `;

--- a/fe/src/components/organisms/Calendar/style.ts
+++ b/fe/src/components/organisms/Calendar/style.ts
@@ -22,8 +22,9 @@ export const Calendar = styled.div`
   border: 2px solid white;
   border-radius: 1rem;
   padding: 1em 0.5em 0.5em;
+  border: 2px solid ${({ theme }) => theme.color.lightBorder};
   :hover {
-    border: 2px solid ${({ theme }) => theme.color.lightBorder};
+    border: 2px solid ${({ theme }) => theme.color.transparentBrandColor};
     ${CenterMonth} {
       color: ${({ theme }) => theme.color.transparentBrandColor};
     }

--- a/fe/src/components/organisms/Calendar/style.ts
+++ b/fe/src/components/organisms/Calendar/style.ts
@@ -22,6 +22,7 @@ export const Calendar = styled.div`
   border: 2px solid white;
   border-radius: 1rem;
   padding: 1em 0.5em 0.5em;
+  margin-top: 1em;
   border: 2px solid ${({ theme }) => theme.color.lightBorder};
   :hover {
     border: 2px solid ${({ theme }) => theme.color.transparentBrandColor};

--- a/fe/src/components/organisms/CalendarBind/index.tsx
+++ b/fe/src/components/organisms/CalendarBind/index.tsx
@@ -54,8 +54,6 @@ const pushEmptyCalendar = (
 };
 
 const dateToYearMonth = (date: Date) => {
-  console.log(date.getFullYear());
-  console.log(date.getMonth());
   return `${date.getFullYear()}-${date.getMonth() + 1}`;
 };
 
@@ -71,8 +69,6 @@ const CalendarBind = ({
   let nowTransactions: any = {};
   let nowSelectedDate = dateToYearMonth(selectedDate.startDate);
   let endDateString = dateToYearMonth(selectedDate.endDate);
-  console.log('endDateString : ', endDateString);
-  console.log('enddateString : ', selectedDate, endDateString);
   if (
     dayjs(selectedDate.startDate).format('YYYY-MM') ===
     dayjs(selectedDate.endDate).format('YYYY-MM')
@@ -94,7 +90,6 @@ const CalendarBind = ({
       endDateString,
       Calendars,
     );
-    console.log(nowYearMonthKey);
     if (checkLoopEnd(nowYearMonthKey, endDateString)) {
       return;
     }
@@ -135,7 +130,6 @@ const CalendarBind = ({
     endDateString !== nowSelectedDate &&
     !checkLoopEnd(nowYearMonthKey, endDateString)
   ) {
-    console.log(nowYearMonthKey);
     if (
       checkLoopEnd(nowYearMonthKey, endDateString) ||
       endDateString === nowSelectedDate

--- a/fe/src/components/organisms/CalendarBind/index.tsx
+++ b/fe/src/components/organisms/CalendarBind/index.tsx
@@ -54,6 +54,8 @@ const pushEmptyCalendar = (
 };
 
 const dateToYearMonth = (date: Date) => {
+  console.log(date.getFullYear());
+  console.log(date.getMonth());
   return `${date.getFullYear()}-${date.getMonth() + 1}`;
 };
 
@@ -69,11 +71,15 @@ const CalendarBind = ({
   let nowTransactions: any = {};
   let nowSelectedDate = dateToYearMonth(selectedDate.startDate);
   let endDateString = dateToYearMonth(selectedDate.endDate);
-
+  console.log('endDateString : ', endDateString);
+  console.log('enddateString : ', selectedDate, endDateString);
   if (
     dayjs(selectedDate.startDate).format('YYYY-MM') ===
     dayjs(selectedDate.endDate).format('YYYY-MM')
   ) {
+    endDateString = nextMonth(endDateString);
+  }
+  if (selectedDate.endDate.getDate() !== 1) {
     endDateString = nextMonth(endDateString);
   }
   Object.entries(transactions).forEach((el) => {
@@ -88,7 +94,7 @@ const CalendarBind = ({
       endDateString,
       Calendars,
     );
-
+    console.log(nowYearMonthKey);
     if (checkLoopEnd(nowYearMonthKey, endDateString)) {
       return;
     }
@@ -129,6 +135,7 @@ const CalendarBind = ({
     endDateString !== nowSelectedDate &&
     !checkLoopEnd(nowYearMonthKey, endDateString)
   ) {
+    console.log(nowYearMonthKey);
     if (
       checkLoopEnd(nowYearMonthKey, endDateString) ||
       endDateString === nowSelectedDate

--- a/fe/src/styles/GlobalStyle.ts
+++ b/fe/src/styles/GlobalStyle.ts
@@ -28,12 +28,7 @@ const GlobalStyle = createGlobalStyle`
       font-size: 16px;
     }
   }
-  button {
-    -moz-appearance: none; /* Firefox */
-    -webkit-appearance: none; /* Safari and Chrome */
-    appearance: none;
-  }
-  input {
+  button, input {
     -moz-appearance: none; /* Firefox */
     -webkit-appearance: none; /* Safari and Chrome */
     appearance: none;

--- a/fe/src/styles/GlobalStyle.ts
+++ b/fe/src/styles/GlobalStyle.ts
@@ -28,6 +28,16 @@ const GlobalStyle = createGlobalStyle`
       font-size: 16px;
     }
   }
+  button {
+    -moz-appearance: none; /* Firefox */
+    -webkit-appearance: none; /* Safari and Chrome */
+    appearance: none;
+  }
+  input {
+    -moz-appearance: none; /* Firefox */
+    -webkit-appearance: none; /* Safari and Chrome */
+    appearance: none;
+  }
 
   menu, ol, ul {
     list-style: none;


### PR DESCRIPTION
## 변경사항
![image](https://user-images.githubusercontent.com/34783156/102487296-ac598580-40ad-11eb-8283-4e094e3d1095.png)

* 1월 1일까지 하면 데이터 없어도 1월 달력이 보입니다.
* 날짜 하나에서 보이는 글자 크기 수정하고 요약된 돈 보여주도록 수정했습니다.

## Linked Issues
closes #319
closes #301
closes #287

## 멘토님들

@boostcamp-2020/accountbook_mentor
