### PR TITLE
가계부 리스트 에러메세지 오른쪽에 치우쳤던 것 수정

### DIFF
--- a/fe/src/components/molecules/CalendarOneDate/index.tsx
+++ b/fe/src/components/molecules/CalendarOneDate/index.tsx
@@ -21,7 +21,10 @@ const CalendarOneDate = ({
   ...props
 }: Props): React.ReactElement => {
   return (
-    <S.CalendarOneDate onClick={(income || expense) && onClick} {...props}>
+    <S.CalendarOneDate
+      onClick={(income || expense || unclassified) && onClick}
+      {...props}
+    >
       <S.DateText>{date}</S.DateText>
       <S.PriceTextWrap>
         <S.IncomeText>

--- a/fe/src/components/molecules/CalendarOneDate/index.tsx
+++ b/fe/src/components/molecules/CalendarOneDate/index.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import utils from 'utils';
 import * as S from './style';
 
 export interface OneDateType {
@@ -23,10 +24,14 @@ const CalendarOneDate = ({
     <S.CalendarOneDate onClick={(income || expense) && onClick} {...props}>
       <S.DateText>{date}</S.DateText>
       <S.PriceTextWrap>
-        <S.IncomeText>{income && `${income}`}</S.IncomeText>
-        <S.ExpenseText>{expense && `${expense}`}</S.ExpenseText>
+        <S.IncomeText>
+          {income && `${utils.summaryOfMoney(income)}원`}
+        </S.IncomeText>
+        <S.ExpenseText>
+          {expense && `${utils.summaryOfMoney(expense)}원`}
+        </S.ExpenseText>
         <S.UnclassifiedText>
-          {unclassified && `${unclassified}`}
+          {unclassified && `${utils.summaryOfMoney(unclassified)}원`}
         </S.UnclassifiedText>
       </S.PriceTextWrap>
       <S.EmptyArea />

--- a/fe/src/components/molecules/CalendarOneDate/style.ts
+++ b/fe/src/components/molecules/CalendarOneDate/style.ts
@@ -5,7 +5,7 @@ export const CalendarOneDate = styled(Button)`
   background-color: ${({ theme }) => theme.color.white};
   border: none;
   width: 14.5%;
-  height: 5rem;
+  height: 4.2rem;
   text-align: left;
   background-color: transparent;
 
@@ -20,28 +20,28 @@ export const DateText = styled.div`
   height: 20%;
 `;
 
+export const EmptyArea = styled.div`
+  height: 30%;
+`;
+
 export const PriceTextWrap = styled.div`
-  margin-top: 2em;
+  margin-top: 0.4em;
   font-size: 0.75rem;
   height: 50%;
   text-align: right;
 `;
 
-export const EmptyArea = styled.div`
-  height: 30%;
-`;
-
 export const IncomeText = styled.div`
-  font-size: 0.4rem;
+  font-size: 0.8rem;
   color: ${({ theme }) => theme.color.brandColor};
 `;
 
 export const ExpenseText = styled.div`
-  font-size: 0.4rem;
+  font-size: 0.8rem;
   color: ${({ theme }) => theme.color.red};
 `;
 
 export const UnclassifiedText = styled.div`
-  font-size: 0.4rem;
+  font-size: 0.8rem;
   color: ${({ theme }) => theme.color.black};
 `;

--- a/fe/src/components/organisms/AccountImageTitleUpdate/style.ts
+++ b/fe/src/components/organisms/AccountImageTitleUpdate/style.ts
@@ -6,6 +6,7 @@ import Input from 'components/atoms/Input';
 export const AccountImageTitleUpdate = styled.div`
   width: 100%;
   height: 100%;
+  position: relative;
   display: flex;
   background-color: ${({ theme }) => theme.color.grayBackground};
 
@@ -57,7 +58,7 @@ export const TitleInput = styled(Input)`
 export const ErrorMessage = styled.div`
   position: absolute;
   font-size: 0.8rem;
-  top: 1.7rem;
-  right: 2rem;
+  top: 1.5rem;
+  right: 1.3rem;
   color: ${({ theme }) => theme.color.red};
 `;

--- a/fe/src/components/organisms/Calendar/style.ts
+++ b/fe/src/components/organisms/Calendar/style.ts
@@ -22,8 +22,9 @@ export const Calendar = styled.div`
   border: 2px solid white;
   border-radius: 1rem;
   padding: 1em 0.5em 0.5em;
+  border: 2px solid ${({ theme }) => theme.color.lightBorder};
   :hover {
-    border: 2px solid ${({ theme }) => theme.color.lightBorder};
+    border: 2px solid ${({ theme }) => theme.color.transparentBrandColor};
     ${CenterMonth} {
       color: ${({ theme }) => theme.color.transparentBrandColor};
     }

--- a/fe/src/components/organisms/Calendar/style.ts
+++ b/fe/src/components/organisms/Calendar/style.ts
@@ -22,6 +22,7 @@ export const Calendar = styled.div`
   border: 2px solid white;
   border-radius: 1rem;
   padding: 1em 0.5em 0.5em;
+  margin-top: 1em;
   border: 2px solid ${({ theme }) => theme.color.lightBorder};
   :hover {
     border: 2px solid ${({ theme }) => theme.color.transparentBrandColor};

--- a/fe/src/components/organisms/CalendarBind/index.tsx
+++ b/fe/src/components/organisms/CalendarBind/index.tsx
@@ -54,6 +54,8 @@ const pushEmptyCalendar = (
 };
 
 const dateToYearMonth = (date: Date) => {
+  console.log(date.getFullYear());
+  console.log(date.getMonth());
   return `${date.getFullYear()}-${date.getMonth() + 1}`;
 };
 
@@ -69,11 +71,15 @@ const CalendarBind = ({
   let nowTransactions: any = {};
   let nowSelectedDate = dateToYearMonth(selectedDate.startDate);
   let endDateString = dateToYearMonth(selectedDate.endDate);
-
+  console.log('endDateString : ', endDateString);
+  console.log('enddateString : ', selectedDate, endDateString);
   if (
     dayjs(selectedDate.startDate).format('YYYY-MM') ===
     dayjs(selectedDate.endDate).format('YYYY-MM')
   ) {
+    endDateString = nextMonth(endDateString);
+  }
+  if (selectedDate.endDate.getDate() !== 1) {
     endDateString = nextMonth(endDateString);
   }
   Object.entries(transactions).forEach((el) => {
@@ -88,7 +94,7 @@ const CalendarBind = ({
       endDateString,
       Calendars,
     );
-
+    console.log(nowYearMonthKey);
     if (checkLoopEnd(nowYearMonthKey, endDateString)) {
       return;
     }
@@ -129,6 +135,7 @@ const CalendarBind = ({
     endDateString !== nowSelectedDate &&
     !checkLoopEnd(nowYearMonthKey, endDateString)
   ) {
+    console.log(nowYearMonthKey);
     if (
       checkLoopEnd(nowYearMonthKey, endDateString) ||
       endDateString === nowSelectedDate

--- a/fe/src/styles/GlobalStyle.ts
+++ b/fe/src/styles/GlobalStyle.ts
@@ -28,12 +28,7 @@ const GlobalStyle = createGlobalStyle`
       font-size: 16px;
     }
   }
-  button {
-    -moz-appearance: none; /* Firefox */
-    -webkit-appearance: none; /* Safari and Chrome */
-    appearance: none;
-  }
-  input {
+  button, input {
     -moz-appearance: none; /* Firefox */
     -webkit-appearance: none; /* Safari and Chrome */
     appearance: none;

--- a/fe/src/styles/GlobalStyle.ts
+++ b/fe/src/styles/GlobalStyle.ts
@@ -28,6 +28,16 @@ const GlobalStyle = createGlobalStyle`
       font-size: 16px;
     }
   }
+  button {
+    -moz-appearance: none; /* Firefox */
+    -webkit-appearance: none; /* Safari and Chrome */
+    appearance: none;
+  }
+  input {
+    -moz-appearance: none; /* Firefox */
+    -webkit-appearance: none; /* Safari and Chrome */
+    appearance: none;
+  }
 
   menu, ol, ul {
     list-style: none;


### PR DESCRIPTION
## [변경사항](https://github.com/boostcamp-2020/Project16-A-Account-Book/pull/330/commits/b69c5f38a85908eeeda756b103f97dd2ef533eab)
![image](https://user-images.githubusercontent.com/34783156/102488957-2559dc80-40b0-11eb-8c68-0acb8336d8cc.png)
데스크탑 사이즈에서 에러메세지 치우쳤던 것 수정했습니다.

## 체크리스트
-[x] 데스크탑에서 중복된 이름입니다가 너무 오른쪽에 치우침 수정

## Linked Issues
closes #322

## 멘토님들

@boostcamp-2020/accountbook_mentor
