### PR TITLE
[FE] Fix: 미분류에서 수정 시 첫 번째 카테고리를 디폴트로 수정

### DIFF
--- a/fe/src/hooks/useTransactionInput.ts
+++ b/fe/src/hooks/useTransactionInput.ts
@@ -55,13 +55,23 @@ const useTransactionInput = (transactionObjId?: string): [State, any] => {
       MethodStore.loadMethods(),
     ]);
   };
-
+  const getUnclassfiedCategoryId = () => {
+    const categories = CategoryStore.getCategories(
+      transactionState.classification,
+    );
+    const foundCategory = categories.find((item) => item.title !== '미분류');
+    if (!foundCategory) {
+      return '';
+    }
+    return foundCategory._id;
+  };
   const loadTransactionAndSetInitialInput = async () => {
     const transaction = await transactionAPI.getTransaction(
       TransactionStore.accountObjId,
       transactionObjId as string,
     );
     const { date, memo, client, price, method, category } = transaction;
+
     setTransaction({
       date: utils.dateFormatter(date),
       client,
@@ -69,7 +79,8 @@ const useTransactionInput = (transactionObjId?: string): [State, any] => {
       memo: memo || '',
       classification: category.type === categoryType.INCOME ? '수입' : '지출',
       method: method._id,
-      category: category._id,
+      category:
+        category.title === '미분류' ? getUnclassfiedCategoryId() : category._id,
     });
   };
   useEffect(() => {


### PR DESCRIPTION
## 변경사항
미분류로 된 거래내역에서 첫 번째 카테고리를 두고 수정을 할 경우 지정이 안되는 버그가 있었습니다.
미분류는 카테고리 리스트에 없으므로, select을 할 수가 없어서
카테고리가 미분류인 경우는, 미분류가 아닌 카테고리 중 하나를 선택하도록 수정하였다.

## 체크리스트
- [ ] 미분류인 카테고리인 거래내역에서 수정시 바로 저장을 누르면 첫 번째 카테고리가 들어가게 된다.
## Linked Issues
closes #331 
## 멘토님들

@boostcamp-2020/accountbook_mentor
