### PR TITLE
통계페이지의 버튼 css 수정 & 타입에 따라 컬러 변경 & 애니메이션 길이 계산 추가

### DIFF
--- a/fe/src/components/molecules/Checkbox/style.ts
+++ b/fe/src/components/molecules/Checkbox/style.ts
@@ -13,6 +13,7 @@ const CheckboxContainer = styled(Button)<Prop>`
   align-items: center;
   background: ${({ theme }) => theme.color.brandColor};
   border: 1px solid ${({ theme }) => theme.color.brandColor};
+  border-radius: 15%;
   > img {
     display: ${({ checked }) => (checked ? 'block' : 'none')};
   }

--- a/fe/src/components/molecules/LineChart/index.tsx
+++ b/fe/src/components/molecules/LineChart/index.tsx
@@ -101,7 +101,7 @@ const LineChart = ({
   const LabelsXAxis = () => {
     const y = yAxisPos.y.end + labelStyle.fontSize;
     const dateLength = data[0].date.length;
-    const labelLength = (labelStyle.fontSize + dateLength) * 1.3;
+    const labelLength = (labelStyle.fontSize + dateLength) * 1.4;
     let lastPrintedX = 0;
     return (
       <>
@@ -174,7 +174,6 @@ const LineChart = ({
       <Polyline
         fill="none"
         stroke={theme.color.brandColor}
-        sd={chartWidth + paddingLeftWidth + 200}
         strokeWidth={STROKE}
         points={points}
       />

--- a/fe/src/components/molecules/LineChart/style.ts
+++ b/fe/src/components/molecules/LineChart/style.ts
@@ -1,16 +1,19 @@
 import styled, { keyframes } from 'styled-components';
+import mathUtils from 'utils/math';
 
 export interface IPolyline {
-  sd: any;
+  points: string;
 }
-const polylineAnimation = (sd: any) => keyframes`
+const polylineAnimation = (length: number) => keyframes`
       from {
-        stroke-dasharray: 0 251; 
+        stroke-dasharray: 0 ${length}; 
       }
       to {
-        stroke-dasharray: ${sd} 251; 
+        stroke-dasharray: ${length} 0; 
       }
 `;
 export const Polyline = styled.polyline<IPolyline>`
-  animation: ${({ sd }) => polylineAnimation(sd)} 1s ease-in-out forwards;
+  animation: ${({ points }) =>
+      polylineAnimation(mathUtils.getPolyLineLength(points))}
+    1s linear forwards;
 `;

--- a/fe/src/components/organisms/PieChartDetail/index.tsx
+++ b/fe/src/components/organisms/PieChartDetail/index.tsx
@@ -4,7 +4,6 @@ import PieChart from 'components/molecules/PieChart';
 import Checkbox from 'components/molecules/Checkbox';
 import PriceTag from 'components/atoms/PriceTag';
 import NoDataPieChartContents from 'components/molecules/NoDataPieChartContents';
-
 import { IStatistics } from 'types';
 import * as S from './style';
 
@@ -27,16 +26,20 @@ const PieChartDetail = ({
 
   const TotalStatusCheckBox = (
     <S.TotalStatusCheckBox>
-      <div className="total-checkbox-wrap">
+      <S.TotalCheckboxWrap>
         <Checkbox checked={checkStatus.income} onClick={onClick} />
-        수입
-        <PriceTag value={statistics.totalPrice.income} />
-      </div>
-      <div className="total-checkbox-wrap">
+        <S.PriceWrap className="income">
+          <span className="category-type">수입</span>
+          <PriceTag value={statistics.totalPrice.income} />
+        </S.PriceWrap>
+      </S.TotalCheckboxWrap>
+      <S.TotalCheckboxWrap className="income">
         <Checkbox checked={checkStatus.expense} onClick={onClick} />
-        지출
-        <PriceTag value={statistics.totalPrice.expense} />
-      </div>
+        <S.PriceWrap className="expense">
+          <span className="category-type">지출</span>
+          <PriceTag value={statistics.totalPrice.expense} />
+        </S.PriceWrap>
+      </S.TotalCheckboxWrap>
     </S.TotalStatusCheckBox>
   );
   return (

--- a/fe/src/components/organisms/PieChartDetail/style.ts
+++ b/fe/src/components/organisms/PieChartDetail/style.ts
@@ -2,11 +2,6 @@ import styled from 'styled-components';
 
 export const TotalStatusCheckBox = styled.div`
   display: flex;
-  .total-checkbox-wrap {
-    display: flex;
-    flex: 1 1 auto;
-    justify-content: center;
-  }
 `;
 export const StatisticsTitle = styled.div`
   margin: 0.5rem 0;
@@ -16,4 +11,20 @@ export const StatisticsTitle = styled.div`
 export const PieChartWrap = styled.div`
   display: flex;
   justify-content: center;
+`;
+
+export const TotalCheckboxWrap = styled.div`
+  display: flex;
+  flex: 1 1 auto;
+  justify-content: center;
+`;
+
+export const PriceWrap = styled.div`
+  margin-left: 0.4em;
+  &.income {
+    color: ${({ theme }) => theme.color.brandColor};
+  }
+  &.expense {
+    color: ${({ theme }) => theme.color.red};
+  }
 `;

--- a/fe/src/components/organisms/PieChartOverview/style.ts
+++ b/fe/src/components/organisms/PieChartOverview/style.ts
@@ -6,6 +6,11 @@ export const TotalViewButton = styled(Button)`
   border: 1px solid gray;
   background: ${({ theme }) => theme.color.white};
   color: gray;
+  :hover {
+    border: 1px solid ${({ theme }) => theme.color.brandColor};
+    background: ${({ theme }) => theme.color.transparentBrandColor};
+    color: ${({ theme }) => theme.color.brandColor};
+  }
 `;
 
 export const StatisticsTitle = styled.div`

--- a/fe/src/utils/__tests__/math.test.ts
+++ b/fe/src/utils/__tests__/math.test.ts
@@ -21,3 +21,16 @@ test('주어진 키에 해당하는 값들을 더한다.', () => {
   const ageList = [{ age: 5 }, { age: 1 }, { age: 3 }];
   expect(math.sumByKey(ageList, 'age')).toBe(9);
 });
+
+test('두 점 사이의 거리를 계산한다', () => {
+  expect(math.getLineLength(10, 10, 0, 0)).toBe(Math.sqrt(200));
+});
+
+test(' "x,y"가 주어졌을 때, 숫자로 된 x, y 의 배열을 반환한다.', () => {
+  expect(math.getPosition('2,4')).toEqual([2, 4]);
+});
+
+test('x,y좌표가 여러 개인 스트링이 주어졌을 때, 해당 polyline의 길이를 계산한다.', () => {
+  const line1 = '1,1 2,2 3,3 4,4';
+  expect(math.getPolyLineLength(line1)).toBe(3 * Math.sqrt(2));
+});

--- a/fe/src/utils/math.ts
+++ b/fe/src/utils/math.ts
@@ -5,4 +5,24 @@ export default {
   sumByKey(array: Array<object>, key: string, base = 0): number {
     return array.reduce((sum: number, value: any) => sum + value[key], base);
   },
+  getLineLength(x1: number, y1: number, x2: number, y2: number): number {
+    return Math.sqrt((x2 - x1) ** 2 + (y2 - y1) ** 2);
+  },
+  getPosition(point: string): [number, number] {
+    const [x, y] = point.split(',');
+    return [+x, +y];
+  },
+  getPolyLineLength(polyLinePoints: string) {
+    const points = polyLinePoints.split(' ');
+    const numOfPoints = points.length;
+    const length = points.reduce((sumLength, point, idx) => {
+      if (idx >= numOfPoints - 1) {
+        return sumLength;
+      }
+      const [x1, y1] = this.getPosition(point);
+      const [x2, y2] = this.getPosition(points[idx + 1]);
+      return sumLength + this.getLineLength(x1, y1, x2, y2);
+    }, 0);
+    return length;
+  },
 };


### PR DESCRIPTION
## 변경사항
- 마우스 올렸을 때 버튼의 색 변경
- 수입. 지출에 따라 다른 색 보여지도록 수정
- 라인 차트 애니메이션에서 라인의 길이를 계산한 후, stroke-dasharray에 넣는 것으로 수정한다.

<img width="1070" alt="스크린샷 2020-12-17 오후 10 56 57" src="https://user-images.githubusercontent.com/43772082/102496764-2c3a1c80-40bb-11eb-8d7d-146741f8c39a.png">
<img width="803" alt="스크린샷 2020-12-17 오후 10 57 07" src="https://user-images.githubusercontent.com/43772082/102496778-31976700-40bb-11eb-816f-3c26e9eefff2.png">

## 체크리스트

## Linked Issues
closes #339 
## 멘토님들

@boostcamp-2020/accountbook_mentor
