### PR TITLE
데이터 없을 때 라인차트 그래프 구현

### DIFF
--- a/fe/src/components/molecules/LineChart/index.tsx
+++ b/fe/src/components/molecules/LineChart/index.tsx
@@ -14,12 +14,14 @@ export interface Props {
   width: number;
   height: number;
   horizontalGuides: number;
+  color?: string;
 }
 const LineChart = ({
   data,
   height,
   width,
   horizontalGuides: numberOfHorizontalGuides,
+  color = theme.color.brandColor,
 }: Props) => {
   const FONT_SIZE = width / 60;
   const maximumXFromData = data.length;
@@ -152,7 +154,7 @@ const LineChart = ({
     return (
       <>
         <polyline
-          stroke={theme.color.brandColor}
+          stroke={color}
           strokeWidth={STROKE}
           points={`${startX},${y} ${endX},${y}`}
         />
@@ -173,7 +175,7 @@ const LineChart = ({
 
       <Polyline
         fill="none"
-        stroke={theme.color.brandColor}
+        stroke={color}
         strokeWidth={STROKE}
         points={points}
       />

--- a/fe/src/components/organisms/LineChartOverview/index.tsx
+++ b/fe/src/components/organisms/LineChartOverview/index.tsx
@@ -1,9 +1,11 @@
 import React from 'react';
 import LineChart from 'components/molecules/LineChart';
+import NodataMessage from 'components/molecules/NoDataMessage';
 import { TransactionStore } from 'stores/Transaction';
 import { observer } from 'mobx-react-lite';
 import { IDateTotalprice } from 'types';
 import dateUtils from 'utils/date';
+import theme from 'styles/theme';
 import * as S from './style';
 
 const checkDataIfScarce = (dataList: IDateTotalprice[]) => dataList.length <= 1;
@@ -27,8 +29,28 @@ const formalizeDate = (dataList: IDateTotalprice[]) => {
     date: dateUtils.dateCustomFormatter(data.date, FORMAT),
   }));
 };
+const noData = [
+  { date: '', totalPrice: 10 },
+  { date: '', totalPrice: 4 },
+  { date: '', totalPrice: 30 },
+  { date: '', totalPrice: 5 },
+  { date: '', totalPrice: 40 },
+  { date: '', totalPrice: 10 },
+  { date: '', totalPrice: 70 },
+];
 
-const WarningMessage = <div>데이터가 충분하지 않습니다 😢 </div>;
+const WarningMessage = (
+  <>
+    <LineChart
+      width={250}
+      height={100}
+      data={noData}
+      color={theme.color.subText}
+      horizontalGuides={5}
+    />
+    <NodataMessage />
+  </>
+);
 
 const LineChartOverview = (): React.ReactElement => {
   const dataList = TransactionStore.totalExpensePriceByDate;


### PR DESCRIPTION
## 변경사항
![스크린샷 2020-12-18 오전 10 06 55](https://user-images.githubusercontent.com/43772082/102561715-c4b2ba00-4118-11eb-885d-f1070565b154.png)

데이터 없을 때 라인차트 그래프 구현하였습니다.
## 체크리스트

## Linked Issues

## 멘토님들

@boostcamp-2020/accountbook_mentor

