### PR TITLE
month header바 반응형 구현

### DIFF
--- a/fe/src/components/organisms/MonthInfoHeader/index.tsx
+++ b/fe/src/components/organisms/MonthInfoHeader/index.tsx
@@ -2,7 +2,6 @@ import React from 'react';
 import { Link, useParams } from 'react-router-dom';
 import { observer } from 'mobx-react-lite';
 import { TransactionStore } from 'stores/Transaction';
-import DateRange from 'components/molecules/DateRange';
 import dayjs from 'dayjs';
 import { ChattingStore } from 'stores/Chatting';
 import * as S from './style';
@@ -33,7 +32,7 @@ const MonthInfoHeader = ({
   const baseUrl = `/transactions/${owner}/${title}`;
   return (
     <S.MonthInfoHeaderContainer>
-      <DateRange dates={date} disabled />
+      <S.DateRangeBox dates={date} disabled />
       <S.MoneyInfo>
         <div className="category-type income">
           <div className="category-type__title ">수입</div>

--- a/fe/src/components/organisms/MonthInfoHeader/index.tsx
+++ b/fe/src/components/organisms/MonthInfoHeader/index.tsx
@@ -1,5 +1,4 @@
 import React from 'react';
-import TotalBox from 'components/molecules/TotalBox';
 import { Link, useParams } from 'react-router-dom';
 import { observer } from 'mobx-react-lite';
 import { TransactionStore } from 'stores/Transaction';
@@ -35,10 +34,16 @@ const MonthInfoHeader = ({
   return (
     <S.MonthInfoHeaderContainer>
       <DateRange dates={date} disabled />
-      <div>
-        <TotalBox title="수입" total={total.income} />
-        <TotalBox title="지출" total={total.expense} />
-      </div>
+      <S.MoneyInfo>
+        <div className="category-type income">
+          <div className="category-type__title ">수입</div>
+          <div className="total-money">{total.income}</div>
+        </div>
+        <div className="category-type expense">
+          <div className="category-type__title">지출</div>
+          <div className="total-money">{total.expense}</div>
+        </div>
+      </S.MoneyInfo>
       <Link to={`${baseUrl}/chatting`}>
         <S.MonthButton
           onClick={() => {

--- a/fe/src/components/organisms/MonthInfoHeader/style.ts
+++ b/fe/src/components/organisms/MonthInfoHeader/style.ts
@@ -2,11 +2,21 @@ import Button from 'components/atoms/Button';
 import styled, { css } from 'styled-components';
 import { ButtonStyleProps } from 'components/atoms/Button/style';
 import { rgba } from 'polished';
+import DateRange from 'components/molecules/DateRange';
 
 export interface MonthHeaderInfoButton extends ButtonStyleProps {
   color?: string;
   border?: boolean;
 }
+
+export const DateRangeBox = styled(DateRange)`
+  @media only screen and (min-width: 300px) {
+    padding: 0;
+  }
+  @media only screen and (min-width: 400px) {
+    padding: 0.5rem 0.2rem;
+  }
+`;
 export const MonthButton = styled(Button)<MonthHeaderInfoButton>`
   color: ${({ color, theme }) =>
     color ? theme.color[color] : theme.color.brandColor};

--- a/fe/src/components/organisms/MonthInfoHeader/style.ts
+++ b/fe/src/components/organisms/MonthInfoHeader/style.ts
@@ -11,9 +11,7 @@ export const MonthButton = styled(Button)<MonthHeaderInfoButton>`
   color: ${({ color, theme }) =>
     color ? theme.color[color] : theme.color.brandColor};
   border: 0;
-  width: 2.5rem;
-  height: 2.5rem;
-  border-radius: 1.25rem;
+  border-radius: 50%;
   border: 1px solid ${({ theme }) => theme.color.brandColor};
   :hover {
     color: ${({ theme }) => theme.color.white};
@@ -26,6 +24,14 @@ export const MonthButton = styled(Button)<MonthHeaderInfoButton>`
       font-weight: 900;
     `}
   background: transparent;
+  @media only screen and (min-width: 300px) {
+    width: 2.5em;
+    height: 2.5em;
+  }
+  @media only screen and (min-width: 400px) {
+    width: 3em;
+    height: 3em;
+  }
 `;
 
 export const MonthInfoHeaderContainer = styled.section`
@@ -40,4 +46,33 @@ export const MonthInfoHeaderContainer = styled.section`
   justify-content: center;
   align-items: center;
   background: ${({ theme }) => theme.color.white};
+`;
+
+export const MoneyInfo = styled.div`
+  display: flex;
+  flex-direction: column;
+  .income {
+    color: ${({ theme }) => theme.color.brandColor};
+  }
+  .expense {
+    color: ${({ theme }) => theme.color.red};
+  }
+  @media only screen and (min-width: 300px) {
+    .category-type {
+      display: flex;
+      flex-direction: column;
+      & + & {
+        margin-top: 1000em;
+      }
+    }
+  }
+  @media only screen and (min-width: 400px) {
+    .category-type {
+      display: flex;
+      flex-direction: row;
+    }
+    .total-money {
+      margin-left: 0.4em;
+    }
+  }
 `;


### PR DESCRIPTION
## 변경사항
width가 300px정도일 때, 금액이 크면 배치가 이상해져서, 작은 화면인 iphone 5/SE 기준으로
month header bar의 배치를 조절하였습니다.
**iphone 5/SE**
- 채팅 크기 줄임
- 수입, 지출을 column으로 배치
- 시작일, 마지막일 부분의 패딩 없앰
![스크린샷 2020-12-18 오전 10 51 59](https://user-images.githubusercontent.com/43772082/102564578-0fcfcb80-411f-11eb-9952-951e085b04d3.png)


## 체크리스트

## Linked Issues

## 멘토님들

@boostcamp-2020/accountbook_mentor
