### PR TITLE
달력 페이지 모달 깨지는 것 수정 / 달력페이지 CSS 수정 / 헤더바 CSS 추가 / 메인페이지 로딩화면 추가

### DIFF
--- a/fe/src/components/molecules/CalendarOneDate/index.tsx
+++ b/fe/src/components/molecules/CalendarOneDate/index.tsx
@@ -28,13 +28,14 @@ const CalendarOneDate = ({
       <S.DateText>{date}</S.DateText>
       <S.PriceTextWrap>
         <S.IncomeText>
-          {income && `${utils.summaryOfMoney(income)}원`}
+          {income !== undefined && `${utils.summaryOfMoney(income)}원`}
         </S.IncomeText>
         <S.ExpenseText>
-          {expense && `${utils.summaryOfMoney(expense)}원`}
+          {expense !== undefined && `${utils.summaryOfMoney(expense)}원`}
         </S.ExpenseText>
         <S.UnclassifiedText>
-          {unclassified && `${utils.summaryOfMoney(unclassified)}원`}
+          {unclassified !== undefined &&
+            `${utils.summaryOfMoney(unclassified)}원`}
         </S.UnclassifiedText>
       </S.PriceTextWrap>
       <S.EmptyArea />

--- a/fe/src/components/molecules/CalendarOneDate/style.ts
+++ b/fe/src/components/molecules/CalendarOneDate/style.ts
@@ -32,16 +32,25 @@ export const PriceTextWrap = styled.div`
 `;
 
 export const IncomeText = styled.div`
-  font-size: 0.8rem;
+  font-size: 0.4rem;
+  @media only screen and (min-width: 500px) {
+    font-size: 0.8rem;
+  }
   color: ${({ theme }) => theme.color.brandColor};
 `;
 
 export const ExpenseText = styled.div`
-  font-size: 0.8rem;
+  font-size: 0.4rem;
+  @media only screen and (min-width: 500px) {
+    font-size: 0.8rem;
+  }
   color: ${({ theme }) => theme.color.red};
 `;
 
 export const UnclassifiedText = styled.div`
-  font-size: 0.8rem;
+  font-size: 0.4rem;
+  @media only screen and (min-width: 500px) {
+    font-size: 0.8rem;
+  }
   color: ${({ theme }) => theme.color.black};
 `;

--- a/fe/src/components/organisms/DateTransactionModal/style.ts
+++ b/fe/src/components/organisms/DateTransactionModal/style.ts
@@ -7,6 +7,12 @@ export const Content = styled.div`
   border-top-left-radius: 1.5rem;
   border-top-right-radius: 1.5rem;
   width: 90%;
+  @media only screen and (min-width: 768px) {
+    width: 69%;
+  }
+  @media only screen and (min-width: 1024px) {
+    width: 65%;
+  }
   height: 30%;
   bottom: -30%;
   z-index: 15;

--- a/fe/src/components/organisms/HeaderBar/index.tsx
+++ b/fe/src/components/organisms/HeaderBar/index.tsx
@@ -23,7 +23,7 @@ const BackButton = (goBack: any) => (
   </div>
 );
 const HeaderBar = ({
-  title = 'N석봉',
+  title = 'N 석 봉',
   back = false,
   ...props
 }: Props): React.ReactElement => {
@@ -44,8 +44,7 @@ const HeaderBar = ({
     <S.HeaderBar {...props}>
       <div className="content">
         {back && BackButton(goBack)}
-
-        <Link to="/accounts" onClick={onClickHandler}>
+        <Link className="header_title" to="/accounts" onClick={onClickHandler}>
           {title}
         </Link>
         <S.Icon icon={bell} onClick={onClickVisible} />

--- a/fe/src/components/organisms/HeaderBar/style.ts
+++ b/fe/src/components/organisms/HeaderBar/style.ts
@@ -36,6 +36,6 @@ export const HeaderBar = styled.div`
 export const Icon = styled(IconButton)`
   position: absolute;
   right: 0;
-  top: -2px;
+  top: -0.08rem;
   background: transparent;
 `;

--- a/fe/src/components/organisms/HeaderBar/style.ts
+++ b/fe/src/components/organisms/HeaderBar/style.ts
@@ -28,6 +28,9 @@ export const HeaderBar = styled.div`
     font-size: ${({ theme }) => theme.fontSize.xs};
     color: ${({ theme }) => theme.color.white};
   }
+  .header_title {
+    font-size: 1.2rem;
+  }
 `;
 
 export const Icon = styled(IconButton)`

--- a/fe/src/components/organisms/HeaderBar/style.ts
+++ b/fe/src/components/organisms/HeaderBar/style.ts
@@ -29,6 +29,11 @@ export const HeaderBar = styled.div`
     color: ${({ theme }) => theme.color.white};
   }
   .header_title {
+    :hover {
+      transition: 0.4s all;
+      cursor: pointer;
+      color: ${({ theme }) => theme.color.white};
+    }
     font-size: 1.2rem;
   }
 `;
@@ -38,4 +43,9 @@ export const Icon = styled(IconButton)`
   right: 0;
   top: -0.08rem;
   background: transparent;
+  transition: 0.4s all;
+  :hover {
+    filter: contrast(120%);
+    transform: rotate(20deg);
+  }
 `;

--- a/fe/src/components/organisms/NoData/style.ts
+++ b/fe/src/components/organisms/NoData/style.ts
@@ -18,7 +18,7 @@ export const NoData = styled.div`
     background-size: 300px 300px;
     -webkit-filter: grayscale(100%);
     filter: gray;
-
+    transition: 1s all;
     :hover {
       -webkit-filter: grayscale(50%);
     }

--- a/fe/src/components/templates/MainTemplate/style.ts
+++ b/fe/src/components/templates/MainTemplate/style.ts
@@ -5,6 +5,15 @@ export const Container = styled.div`
   .main-contaner {
     width: 100%;
   }
+
+  .emptyList {
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    margin-top: 20%;
+    width: 100%;
+    height: 100%;
+  }
 `;
 
 export const FilterBar = styled(FilterBarComponent)`

--- a/fe/src/pages/AccountListPage/index.tsx
+++ b/fe/src/pages/AccountListPage/index.tsx
@@ -108,7 +108,7 @@ const AccountListPage = () => {
 
   return (
     <Template
-      HeaderBar={<Header />}
+      HeaderBar={<Header title="가계부 목록" />}
       Contents={Contents}
       NavBar={newAccountBtn}
     />

--- a/fe/src/pages/CalendarPage/index.tsx
+++ b/fe/src/pages/CalendarPage/index.tsx
@@ -52,7 +52,7 @@ const CalenderPage = () => {
 
     return (
       <Template
-        HeaderBar={<Header />}
+        HeaderBar={<Header title="달 력" />}
         SubHeaderBar={SubHeaderBar}
         Contents={ContentsComponent}
         NavBar={<NavBarComponent />}
@@ -78,7 +78,7 @@ const CalenderPage = () => {
 
   return (
     <Template
-      HeaderBar={<Header />}
+      HeaderBar={<Header title="달 력" />}
       SubHeaderBar={SubHeaderBar}
       Contents={Contents}
       NavBar={<NavBarComponent />}

--- a/fe/src/pages/CalendarPage/styles.ts
+++ b/fe/src/pages/CalendarPage/styles.ts
@@ -1,6 +1,7 @@
 import styled from 'styled-components';
 
 export const Contents = styled.div`
+  width: 100%;
   .toggleSwitch {
     margin-top: 1em;
     margin-left: 0.8em;

--- a/fe/src/pages/CategoryPage/index.tsx
+++ b/fe/src/pages/CategoryPage/index.tsx
@@ -243,7 +243,7 @@ function CategoryPage(): React.ReactElement {
   );
   return (
     <MainTemplate
-      HeaderBar={<Header />}
+      HeaderBar={<Header title="태 그" />}
       Contents={bodyContent}
       NavBar={<NavBarComponent />}
     />

--- a/fe/src/pages/ChattingPage/index.tsx
+++ b/fe/src/pages/ChattingPage/index.tsx
@@ -96,7 +96,7 @@ const ChattingPage = () => {
   );
   return (
     <MainTemplate
-      HeaderBar={<Header />}
+      HeaderBar={<Header title="채 팅" />}
       Contents={ChattingContent}
       NavBar={<NavBar />}
     />

--- a/fe/src/pages/MainPage/index.tsx
+++ b/fe/src/pages/MainPage/index.tsx
@@ -46,7 +46,7 @@ const MainPage = () => {
   if (TransactionStore.state === state.PENDING) {
     return (
       <Template
-        HeaderBar={<Header />}
+        HeaderBar={<Header title="홈" />}
         SubHeaderBar={<MonthInfo />}
         Contents={renderLoading}
         NavBar={<NavBarComponent />}
@@ -56,7 +56,7 @@ const MainPage = () => {
 
   return (
     <Template
-      HeaderBar={<Header />}
+      HeaderBar={<Header title="홈" />}
       SubHeaderBar={<MonthInfo />}
       Contents={Contents}
       NavBar={<NavBarComponent />}

--- a/fe/src/pages/MainPage/index.tsx
+++ b/fe/src/pages/MainPage/index.tsx
@@ -1,6 +1,6 @@
 import React, { useEffect } from 'react';
 import { observer } from 'mobx-react-lite';
-import { TransactionStore } from 'stores/Transaction';
+import { TransactionStore, state } from 'stores/Transaction';
 import { useHistory, useParams } from 'react-router-dom';
 import Template from 'components/templates/MainTemplate';
 import Header from 'components/organisms/HeaderBar';
@@ -8,6 +8,7 @@ import FilterBar from 'components/organisms/FilterBar';
 import MonthInfo from 'components/organisms/MonthInfoHeader';
 import NavBarComponent from 'components/organisms/NavBar';
 import NoData from 'components/organisms/NoData';
+import loadingImg from 'assets/svg/loading.svg';
 import TransactionDateList from './TransactionDateList';
 
 const MainPage = () => {
@@ -35,6 +36,23 @@ const MainPage = () => {
       )}
     </>
   );
+
+  const renderLoading = (
+    <div className="emptyList" id="loading">
+      <img id="loadingImg" src={loadingImg} alt="loading..." />
+    </div>
+  );
+
+  if (TransactionStore.state === state.PENDING) {
+    return (
+      <Template
+        HeaderBar={<Header />}
+        SubHeaderBar={<MonthInfo />}
+        Contents={renderLoading}
+        NavBar={<NavBarComponent />}
+      />
+    );
+  }
 
   return (
     <Template

--- a/fe/src/pages/StatisticsDetailPage/index.tsx
+++ b/fe/src/pages/StatisticsDetailPage/index.tsx
@@ -36,7 +36,7 @@ const StatisticsDetailPage = () => {
 
   return (
     <Template
-      HeaderBar={<Header />}
+      HeaderBar={<Header title="통 계" />}
       SubHeaderBar={SubHeaderBar}
       Contents={Contents}
       NavBar={<NavBarComponent />}

--- a/fe/src/pages/StatisticsPage/index.tsx
+++ b/fe/src/pages/StatisticsPage/index.tsx
@@ -34,7 +34,7 @@ const StatisticsPage = ({ location }: { location: any }) => {
 
   return (
     <Template
-      HeaderBar={<Header />}
+      HeaderBar={<Header title="통 계" />}
       SubHeaderBar={SubHeaderBar}
       Contents={Contents}
       NavBar={<NavBarComponent />}


### PR DESCRIPTION
## 변경사항
### 달력 모달 데스크탑에서 깨지던 것 수정
![image](https://user-images.githubusercontent.com/34783156/102566478-f9c40a00-4122-11eb-8d44-aba1e1ebc830.png)

### 달력페이지 모바일에서 안깨지도록 글씨 크기 반응형으로 수정
![image](https://user-images.githubusercontent.com/34783156/102566489-fd579100-4122-11eb-9f7a-ef33662af175.png)

### 헤더바 CSS 추가
![adwbf](https://user-images.githubusercontent.com/34783156/102566528-14967e80-4123-11eb-91d4-129fd39ef896.gif)

### 메인페이지 로딩화면 추가
다른 가계부로 이동할 때 이전 가계부 목록이 잠깐 보였던 버그가 있었는데 이제 보이지 않고 로딩화면이 뜹니다.

## 체크리스트
-   [ ] 메인페이지에서 transaction받아오고 있는 중에 로딩페이지를 보여주는지

## Linked Issues
closes #348

## 멘토님들

@boostcamp-2020/accountbook_mentor
